### PR TITLE
Feature/request password reset

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -70,6 +70,7 @@ func Setup(ctx context.Context, r *mux.Router, cognitoClient cognito.Client, use
 	// self used in paths rather than identifier as the identifier is a Cognito Session string in change password requests
 	// the user id is not yet available from the previous responses
 	r.HandleFunc("/v1/users/self/password", contextAndErrors(api.ChangePasswordHandler)).Methods("PUT")
+	r.HandleFunc("/v1/password-reset", contextAndErrors(api.PasswordResetHandler)).Methods("POST")
 	return api, nil
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -28,6 +28,7 @@ func TestSetup(t *testing.T) {
 			So(hasRoute(api.Router, "/v1/tokens/self", "PUT"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/v1/users", "POST"), ShouldBeTrue)
 			So(hasRoute(api.Router, "/v1/users/self/password", "PUT"), ShouldBeTrue)
+			So(hasRoute(api.Router, "/v1/password-reset", "POST"), ShouldBeTrue)
 		})
 
 		Convey("No error returned when user pool id supplied", func() {

--- a/api/users.go
+++ b/api/users.go
@@ -151,17 +151,10 @@ func (api *API) PasswordResetHandler(ctx context.Context, w http.ResponseWriter,
 
 	forgotPasswordRequest := passwordResetParams.BuildCognitoRequest(api.ClientSecret, api.ClientId)
 
-	result, err := api.CognitoClient.ForgotPassword(forgotPasswordRequest)
+	_, err = api.CognitoClient.ForgotPassword(forgotPasswordRequest)
 	if err != nil {
 		responseErr := models.NewCognitoError(ctx, err, "ForgotPassword request from password reset endpoint")
 		if responseErr.Code == models.InternalError {
-			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
-		}
-	}
-
-	if result != nil {
-		responseErr := passwordResetParams.BuildSuccessfulJsonResponse(ctx, result)
-		if responseErr != nil {
 			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
 		}
 	}

--- a/api/users.go
+++ b/api/users.go
@@ -128,7 +128,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, w http.ResponseWriter
 	return models.NewSuccessResponse(jsonResponse, http.StatusAccepted, headers), nil
 }
 
-//PasswordResetHandler creates a new user and returns a http handler interface
+//PasswordResetHandler requests a password reset email be sent to the user and returns a http handler interface
 func (api *API) PasswordResetHandler(ctx context.Context, w http.ResponseWriter, req *http.Request) (*models.SuccessResponse, *models.ErrorResponse) {
 	defer req.Body.Close()
 

--- a/api/users.go
+++ b/api/users.go
@@ -154,7 +154,9 @@ func (api *API) PasswordResetHandler(ctx context.Context, w http.ResponseWriter,
 	_, err = api.CognitoClient.ForgotPassword(forgotPasswordRequest)
 	if err != nil {
 		responseErr := models.NewCognitoError(ctx, err, "ForgotPassword request from password reset endpoint")
-		if responseErr.Code == models.InternalError {
+		if responseErr.Code == models.LimitExceededError || responseErr.Code == models.TooManyRequestsError {
+			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusBadRequest, nil)
+		} else if responseErr.Code != models.UserNotFoundError && responseErr.Code != models.UserNotConfirmedError {
 			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
 		}
 	}

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -422,8 +422,8 @@ func TestPasswordResetHandler(t *testing.T) {
 			{
 				// Cognito invalid user
 				func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
-					awsErrCode := "CodeMismatchException"
-					awsErrMessage := "session invalid"
+					awsErrCode := "UserNotFoundException"
+					awsErrMessage := "user not found in user pool"
 					awsOrigErr := errors.New(awsErrCode)
 					awsErr := awserr.New(awsErrCode, awsErrMessage, awsOrigErr)
 					return nil, awsErr

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -19,6 +19,7 @@ import (
 
 const usersEndPoint = "http://localhost:25600/v1/users"
 const changePasswordEndPoint = "http://localhost:25600/v1/users/self/password"
+const requestResetEndPoint = "http://localhost:25600/v1/password-reset"
 
 func TestCreateUserHandler(t *testing.T) {
 
@@ -369,6 +370,118 @@ func TestChangePasswordHandler(t *testing.T) {
 			r := httptest.NewRequest(http.MethodPut, changePasswordEndPoint, bytes.NewReader(body))
 
 			successResponse, errorResponse := api.ChangePasswordHandler(ctx, w, r)
+
+			So(successResponse, ShouldBeNil)
+			So(errorResponse.Status, ShouldEqual, tt.httpResponse)
+			So(len(errorResponse.Errors), ShouldEqual, 1)
+			castErr := errorResponse.Errors[0].(*models.Error)
+			So(castErr.Code, ShouldEqual, tt.errorCode)
+		}
+	})
+}
+
+func TestPasswordResetHandler(t *testing.T) {
+
+	var (
+		routeMux                                        = mux.NewRouter()
+		ctx                                             = context.Background()
+		poolId, clientId, clientSecret, authFlow string = "us-west-11_bxushuds", "abc123", "bsjahsaj9djsiq", "authflow"
+		email, password, session                 string = "foo_bar123@ext.ons.gov.uk", "Password2", "auth-challenge-session"
+	)
+
+	m := &mock.MockCognitoIdentityProviderClient{}
+
+	api, _ := Setup(ctx, routeMux, m, poolId, clientId, clientSecret, authFlow)
+	w := httptest.NewRecorder()
+
+	Convey("ForgotPassword - check expected responses", t, func() {
+		respondToAuthChallengeTests := []struct {
+			forgotPasswordFunction func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error)
+			httpResponse           int
+		}{
+			{
+				// Cognito successful password change
+				func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
+					return &cognitoidentityprovider.ForgotPasswordOutput{
+						CodeDeliveryDetails: &cognitoidentityprovider.CodeDeliveryDetailsType{},
+					}, nil
+				},
+				http.StatusAccepted,
+			},
+			{
+				// Cognito internal error
+				func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
+					awsErrCode := "InternalErrorException"
+					awsErrMessage := "Something strange happened"
+					awsOrigErr := errors.New(awsErrCode)
+					awsErr := awserr.New(awsErrCode, awsErrMessage, awsOrigErr)
+					return nil, awsErr
+				},
+				http.StatusInternalServerError,
+			},
+			{
+				// Cognito invalid user
+				func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
+					awsErrCode := "CodeMismatchException"
+					awsErrMessage := "session invalid"
+					awsOrigErr := errors.New(awsErrCode)
+					awsErr := awserr.New(awsErrCode, awsErrMessage, awsOrigErr)
+					return nil, awsErr
+				},
+				http.StatusAccepted,
+			},
+		}
+
+		for _, tt := range respondToAuthChallengeTests {
+			m.ForgotPasswordFunc = tt.forgotPasswordFunction
+
+			postBody := map[string]interface{}{"type": models.NewPasswordRequiredType, "email": email, "password": password, "session": session}
+			body, _ := json.Marshal(postBody)
+			r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(body))
+
+			successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
+
+			// Check whether testing a success or error case
+			if tt.httpResponse > 399 {
+				So(successResponse, ShouldBeNil)
+				So(errorResponse.Status, ShouldEqual, tt.httpResponse)
+			} else {
+				So(successResponse.Status, ShouldEqual, tt.httpResponse)
+				So(errorResponse, ShouldBeNil)
+			}
+		}
+	})
+
+	Convey("ForgotPassword returns 500: error unmarshalling request body", t, func() {
+		r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(nil))
+
+		successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
+
+		So(successResponse, ShouldBeNil)
+		castErr := errorResponse.Errors[0].(*models.Error)
+		So(castErr.Code, ShouldEqual, models.JSONUnmarshalError)
+		So(castErr.Description, ShouldEqual, models.ErrorUnmarshalFailedDescription)
+	})
+
+	Convey("Validation fails 400: validation of a required param throws validation errors", t, func() {
+		validationTests := []struct {
+			requestBody  map[string]interface{}
+			errorCode    string
+			httpResponse int
+		}{
+			// missing a change request param
+			{
+				map[string]interface{}{"type": models.NewPasswordRequiredType, "email": "", "password": password, "session": session},
+				models.InvalidEmailError,
+				http.StatusBadRequest,
+			},
+		}
+
+		for _, tt := range validationTests {
+			body, _ := json.Marshal(tt.requestBody)
+			r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(body))
+
+			successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
 
 			So(successResponse, ShouldBeNil)
 			So(errorResponse.Status, ShouldEqual, tt.httpResponse)

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -420,6 +420,17 @@ func TestPasswordResetHandler(t *testing.T) {
 				http.StatusInternalServerError,
 			},
 			{
+				// Cognito too many requests
+				func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
+					awsErrCode := "TooManyRequestsException"
+					awsErrMessage := "slow down"
+					awsOrigErr := errors.New(awsErrCode)
+					awsErr := awserr.New(awsErrCode, awsErrMessage, awsOrigErr)
+					return nil, awsErr
+				},
+				http.StatusBadRequest,
+			},
+			{
 				// Cognito invalid user
 				func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
 					awsErrCode := "UserNotFoundException"

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -386,7 +386,7 @@ func TestPasswordResetHandler(t *testing.T) {
 		routeMux                                        = mux.NewRouter()
 		ctx                                             = context.Background()
 		poolId, clientId, clientSecret, authFlow string = "us-west-11_bxushuds", "abc123", "bsjahsaj9djsiq", "authflow"
-		email, password, session                 string = "foo_bar123@ext.ons.gov.uk", "Password2", "auth-challenge-session"
+		email                                    string = "foo_bar123@ext.ons.gov.uk"
 	)
 
 	m := &mock.MockCognitoIdentityProviderClient{}
@@ -435,7 +435,7 @@ func TestPasswordResetHandler(t *testing.T) {
 		for _, tt := range respondToAuthChallengeTests {
 			m.ForgotPasswordFunc = tt.forgotPasswordFunction
 
-			postBody := map[string]interface{}{"type": models.NewPasswordRequiredType, "email": email, "password": password, "session": session}
+			postBody := map[string]interface{}{"email": email}
 			body, _ := json.Marshal(postBody)
 			r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(body))
 
@@ -471,7 +471,7 @@ func TestPasswordResetHandler(t *testing.T) {
 		}{
 			// missing a change request param
 			{
-				map[string]interface{}{"type": models.NewPasswordRequiredType, "email": "", "password": password, "session": session},
+				map[string]interface{}{"email": ""},
 				models.InvalidEmailError,
 				http.StatusBadRequest,
 			},

--- a/cognito/cognito.go
+++ b/cognito/cognito.go
@@ -13,4 +13,5 @@ type Client interface {
 	ListUsers(input *cognito.ListUsersInput) (*cognito.ListUsersOutput, error)
 	AdminUserGlobalSignOut(input *cognito.AdminUserGlobalSignOutInput) (*cognito.AdminUserGlobalSignOutOutput, error)
 	RespondToAuthChallenge(input *cognito.RespondToAuthChallengeInput) (*cognito.RespondToAuthChallengeOutput, error)
+	ForgotPassword(input *cognito.ForgotPasswordInput) (*cognito.ForgotPasswordOutput, error)
 }

--- a/cognito/mock/cognito.go
+++ b/cognito/mock/cognito.go
@@ -14,6 +14,7 @@ type MockCognitoIdentityProviderClient struct {
 	InitiateAuthFunc           func(authInput *cognitoidentityprovider.InitiateAuthInput) (*cognitoidentityprovider.InitiateAuthOutput, error)
 	AdminUserGlobalSignOutFunc func(adminUserGlobalSignOutInput *cognitoidentityprovider.AdminUserGlobalSignOutInput) (*cognitoidentityprovider.AdminUserGlobalSignOutOutput, error)
 	RespondToAuthChallengeFunc func(input *cognitoidentityprovider.RespondToAuthChallengeInput) (*cognitoidentityprovider.RespondToAuthChallengeOutput, error)
+	ForgotPasswordFunc         func(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error)
 }
 
 func (m *MockCognitoIdentityProviderClient) DescribeUserPool(poolInputData *cognitoidentityprovider.DescribeUserPoolInput) (*cognitoidentityprovider.DescribeUserPoolOutput, error) {
@@ -43,4 +44,8 @@ func (m *MockCognitoIdentityProviderClient) AdminUserGlobalSignOut(adminUserGlob
 
 func (m *MockCognitoIdentityProviderClient) RespondToAuthChallenge(input *cognitoidentityprovider.RespondToAuthChallengeInput) (*cognitoidentityprovider.RespondToAuthChallengeOutput, error) {
 	return m.RespondToAuthChallengeFunc(input)
+}
+
+func (m *MockCognitoIdentityProviderClient) ForgotPassword(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
+	return m.ForgotPasswordFunc(input)
 }

--- a/cognito/mock/cognito_stub.go
+++ b/cognito/mock/cognito_stub.go
@@ -221,3 +221,20 @@ func (m *CognitoIdentityProviderClientStub) RespondToAuthChallenge(input *cognit
 		return nil, errors.New("InvalidParameterException: Unknown Auth Flow")
 	}
 }
+
+func (m *CognitoIdentityProviderClientStub) ForgotPassword(input *cognitoidentityprovider.ForgotPasswordInput) (*cognitoidentityprovider.ForgotPasswordOutput, error) {
+	forgotPasswordOutput := &cognitoidentityprovider.ForgotPasswordOutput{
+		CodeDeliveryDetails: &cognitoidentityprovider.CodeDeliveryDetailsType{},
+	}
+
+	if *input.Username == "internal.error@ons.gov.uk" {
+		return nil, awserr.New(cognitoidentityprovider.ErrCodeInternalErrorException, "Something went wrong", nil)
+	}
+
+	for _, user := range m.Users {
+		if user.email == *input.Username {
+			return forgotPasswordOutput, nil
+		}
+	}
+	return nil, awserr.New(cognitoidentityprovider.ErrCodeUserNotFoundException, "user not found", nil)
+}

--- a/cognito/mock/cognito_stub.go
+++ b/cognito/mock/cognito_stub.go
@@ -230,6 +230,9 @@ func (m *CognitoIdentityProviderClientStub) ForgotPassword(input *cognitoidentit
 	if *input.Username == "internal.error@ons.gov.uk" {
 		return nil, awserr.New(cognitoidentityprovider.ErrCodeInternalErrorException, "Something went wrong", nil)
 	}
+	if *input.Username == "too.many@ons.gov.uk" {
+		return nil, awserr.New(cognitoidentityprovider.ErrCodeTooManyRequestsException, "Slow down", nil)
+	}
 
 	for _, user := range m.Users {
 		if user.email == *input.Username {

--- a/features/users.feature
+++ b/features/users.feature
@@ -491,3 +491,71 @@ Feature: Users
             }
         """
         Then the HTTP status code should be "202"
+
+    Scenario: POST /v1/password-reset and checking the response status 202
+        Given a user with email "email@ons.gov.uk" and password "Passw0rd!" exists in the database
+        When I POST "/v1/password-reset"
+            """
+                {
+                    "email": "email@ons.gov.uk"
+                }
+            """
+        Then the HTTP status code should be "202"
+
+    Scenario: POST /v1/password-reset missing email and checking the response status 400
+        Given a user with email "email@ons.gov.uk" and password "Passw0rd!" exists in the database
+        When I POST "/v1/password-reset"
+            """
+                {
+                    "email": ""
+                }
+            """
+        Then I should receive the following JSON response with status "400":
+            """
+                {
+                    "errors": [
+                        {
+                            "code": "InvalidEmail",
+                            "description": "the submitted email could not be validated"
+                        }
+                    ]
+                }
+            """
+
+    Scenario: POST /v1/password-reset non ONS email address and checking the response status 202
+        When I POST "/v1/password-reset"
+        """
+            {
+                "email": "email@gmail.com"
+            }
+        """
+        Then the HTTP status code should be "202"
+
+    Scenario: POST /v1/password-reset Cognito internal error
+        Given an internal server error is returned from Cognito
+        When I POST "/v1/password-reset"
+        """
+            {
+                "email": "internal.error@ons.gov.uk"
+            }
+        """
+        Then I should receive the following JSON response with status "500":
+        """
+            {
+                "errors": [
+                    {
+                        "code": "InternalServerError",
+                        "description": "Something went wrong"
+                    }
+                ]
+            }
+        """
+
+    Scenario: POST /v1/password-reset Cognito user not found
+        When I POST "/v1/password-reset"
+        """
+            {
+                "email": "email@ons.gov.uk"
+            }
+        """
+        Then the HTTP status code should be "202"

--- a/features/users.feature
+++ b/features/users.feature
@@ -551,6 +551,26 @@ Feature: Users
             }
         """
 
+    Scenario: POST /v1/password-reset Cognito too many requests error
+        Given an internal server error is returned from Cognito
+        When I POST "/v1/password-reset"
+        """
+            {
+                "email": "too.many@ons.gov.uk"
+            }
+        """
+        Then I should receive the following JSON response with status "400":
+        """
+            {
+                "errors": [
+                    {
+                        "code": "TooManyRequests",
+                        "description": "Slow down"
+                    }
+                ]
+            }
+        """
+
     Scenario: POST /v1/password-reset Cognito user not found
         When I POST "/v1/password-reset"
         """

--- a/models/error_content.go
+++ b/models/error_content.go
@@ -17,6 +17,7 @@ const (
 	InvalidTokenError            = "InvalidToken"
 	InternalError                = "InternalServerError"
 	NotFoundError                = "NotFound"
+	UserNotFoundError            = "UserNotFound"
 	AlreadyExistsError           = "AlreadyExists"
 	DeliveryFailureError         = "DeliveryFailure"
 	InvalidCodeError             = "InvalidCode"
@@ -81,7 +82,7 @@ var CognitoErrorMapping = map[string]string{
 	cognitoidentityprovider.ErrCodeTooManyFailedAttemptsException:  TooManyFailedAttemptsError,
 	cognitoidentityprovider.ErrCodeTooManyRequestsException:        TooManyRequestsError,
 	cognitoidentityprovider.ErrCodeUserNotConfirmedException:       UserNotConfirmedError,
-	cognitoidentityprovider.ErrCodeUserNotFoundException:           NotFoundError,
+	cognitoidentityprovider.ErrCodeUserNotFoundException:           UserNotFoundError,
 	cognitoidentityprovider.ErrCodeUsernameExistsException:         UsernameExistsError,
 	request.ErrCodeSerialization:                                   InternalError,
 	request.ErrCodeRead:                                            InternalError,

--- a/models/users.go
+++ b/models/users.go
@@ -67,7 +67,7 @@ func (p UserParams) BuildListUserRequest(filterString string, requiredAttribute 
 
 func (p UserParams) BuildCreateUserRequest(userId string, userPoolId string) *cognitoidentityprovider.AdminCreateUserInput {
 	var (
-		deliveryMethod, forenameAttrName, surnameAttrName, emailAttrName string = "EMAIL", "name", "family_name", "email"
+		deliveryMethod, forenameAttrName, surnameAttrName, emailAttrName, emailVerifiedAttrName, emailVerifiedValue string = "EMAIL", "name", "family_name", "email", "email_verified", "true"
 	)
 
 	return &cognitoidentityprovider.AdminCreateUserInput{
@@ -83,6 +83,10 @@ func (p UserParams) BuildCreateUserRequest(userId string, userPoolId string) *co
 			{
 				Name:  &emailAttrName,
 				Value: &p.Email,
+			},
+			{
+				Name:  &emailVerifiedAttrName,
+				Value: &emailVerifiedValue,
 			},
 		},
 		DesiredDeliveryMediums: []*string{

--- a/models/users.go
+++ b/models/users.go
@@ -246,3 +246,12 @@ func (p *PasswordReset) Validate(ctx context.Context) error {
 	}
 	return nil
 }
+
+func (p PasswordReset) BuildCognitoRequest(clientSecret string, clientId string) *cognitoidentityprovider.ForgotPasswordInput {
+	secretHash := utilities.ComputeSecretHash(clientSecret, p.Email, clientId)
+	return &cognitoidentityprovider.ForgotPasswordInput{
+		ClientId:   &clientId,
+		SecretHash: &secretHash,
+		Username:   &p.Email,
+	}
+}

--- a/models/users.go
+++ b/models/users.go
@@ -67,7 +67,7 @@ func (p UserParams) BuildListUserRequest(filterString string, requiredAttribute 
 
 func (p UserParams) BuildCreateUserRequest(userId string, userPoolId string) *cognitoidentityprovider.AdminCreateUserInput {
 	var (
-		deliveryMethod, forenameAttrName, surnameAttrName, emailAttrName, emailVerifiedAttrName, emailVerifiedValue string = "EMAIL", "name", "family_name", "email", "email_verified", "true"
+		deliveryMethod, forenameAttrName, surnameAttrName, emailAttrName, emailVerifiedAttrName, emailVerifiedValue string = "EMAIL", "given_name", "family_name", "email", "email_verified", "true"
 	)
 
 	return &cognitoidentityprovider.AdminCreateUserInput{

--- a/models/users.go
+++ b/models/users.go
@@ -255,3 +255,10 @@ func (p PasswordReset) BuildCognitoRequest(clientSecret string, clientId string)
 		Username:   &p.Email,
 	}
 }
+
+func (p *PasswordReset) BuildSuccessfulJsonResponse(ctx context.Context, result *cognitoidentityprovider.ForgotPasswordOutput) error {
+	if result.CodeDeliveryDetails == nil {
+		return NewValidationError(ctx, InternalError, UnrecognisedCognitoResponseDescription)
+	}
+	return nil
+}

--- a/models/users.go
+++ b/models/users.go
@@ -259,10 +259,3 @@ func (p PasswordReset) BuildCognitoRequest(clientSecret string, clientId string)
 		Username:   &p.Email,
 	}
 }
-
-func (p *PasswordReset) BuildSuccessfulJsonResponse(ctx context.Context, result *cognitoidentityprovider.ForgotPasswordOutput) error {
-	if result.CodeDeliveryDetails == nil {
-		return NewValidationError(ctx, InternalError, UnrecognisedCognitoResponseDescription)
-	}
-	return nil
-}

--- a/models/users.go
+++ b/models/users.go
@@ -235,3 +235,14 @@ func (p ChangePassword) BuildAuthChallengeSuccessfulJsonResponse(ctx context.Con
 		return nil, NewValidationError(ctx, InternalError, UnrecognisedCognitoResponseDescription)
 	}
 }
+
+type PasswordReset struct {
+	Email string `json:"email"`
+}
+
+func (p *PasswordReset) Validate(ctx context.Context) error {
+	if !validation.IsEmailValid(p.Email) {
+		return NewValidationError(ctx, InvalidEmailError, InvalidEmailDescription)
+	}
+	return nil
+}

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -553,7 +553,7 @@ func TestPasswordReset_BuildCognitoRequest(t *testing.T) {
 		response := passwordResetParams.BuildCognitoRequest(clientSecret, clientId)
 
 		So(*response.Username, ShouldEqual, passwordResetParams.Email)
-		So(*response.SecretHash, ShouldEqual, ShouldNotBeEmpty)
+		So(*response.SecretHash, ShouldNotBeEmpty)
 		So(*response.ClientId, ShouldResemble, clientId)
 	})
 }

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -539,3 +539,21 @@ func TestPasswordReset_Validate(t *testing.T) {
 		So(validationErr, ShouldBeNil)
 	})
 }
+
+func TestPasswordReset_BuildCognitoRequest(t *testing.T) {
+	Convey("builds a correctly populated Cognito ForgotPasswordInput request body", t, func() {
+
+		passwordResetParams := models.PasswordReset{
+			Email: "email@gmail.com",
+		}
+
+		clientId := "awsclientid"
+		clientSecret := "awsSectret"
+
+		response := passwordResetParams.BuildCognitoRequest(clientSecret, clientId)
+
+		So(*response.Username, ShouldEqual, passwordResetParams.Email)
+		So(*response.SecretHash, ShouldEqual, ShouldNotBeEmpty)
+		So(*response.ClientId, ShouldResemble, clientId)
+	})
+}

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -503,3 +503,39 @@ func TestChangePassword_BuildAuthChallengeSuccessfulJsonResponse(t *testing.T) {
 		So(body["expirationTime"], ShouldNotBeNil)
 	})
 }
+
+func TestPasswordReset_Validate(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("returns validation errors if required parameters are missing", t, func() {
+		missingParamsTests := []struct {
+			Email         string
+			ExpectedError string
+		}{
+			{
+				// missing email
+				"",
+				"InvalidEmail",
+			},
+		}
+		for _, tt := range missingParamsTests {
+			passwordChangeParams := models.PasswordReset{
+				Email: tt.Email,
+			}
+
+			validationErr := passwordChangeParams.Validate(ctx)
+
+			castErr := validationErr.(*models.Error)
+			So(castErr.Code, ShouldEqual, tt.ExpectedError)
+		}
+	})
+
+	Convey("returns nil if there are no validation failures", t, func() {
+		passwordResetParams := models.PasswordReset{
+			Email: "email@gmail.com",
+		}
+		validationErr := passwordResetParams.Validate(ctx)
+
+		So(validationErr, ShouldBeNil)
+	})
+}

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -565,23 +565,21 @@ func TestPasswordReset_BuildSuccessfulJsonResponse(t *testing.T) {
 		passwordResetParams := models.PasswordReset{}
 		result := cognitoidentityprovider.ForgotPasswordOutput{}
 
-		response, err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
+		err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
 
-		So(response, ShouldBeNil)
 		castErr := err.(*models.Error)
 		So(castErr.Code, ShouldEqual, models.InternalError)
 		So(castErr.Description, ShouldEqual, models.UnrecognisedCognitoResponseDescription)
 	})
 
-	Convey("returns a byte array of the response JSON", t, func() {
+	Convey("returns no error when given an expected Cognito response", t, func() {
 		passwordResetParams := models.PasswordReset{}
 		result := cognitoidentityprovider.ForgotPasswordOutput{
-			CodeDeliveryDetails: nil,
+			CodeDeliveryDetails: &cognitoidentityprovider.CodeDeliveryDetailsType{},
 		}
 
-		response, err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
+		err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
 
 		So(err, ShouldBeNil)
-		So(reflect.TypeOf(response), ShouldEqual, reflect.TypeOf([]byte{}))
 	})
 }

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -557,3 +557,31 @@ func TestPasswordReset_BuildCognitoRequest(t *testing.T) {
 		So(*response.ClientId, ShouldResemble, clientId)
 	})
 }
+
+func TestPasswordReset_BuildSuccessfulJsonResponse(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("returns an InternalServerError if the Cognito response does not meet expected format", t, func() {
+		passwordResetParams := models.PasswordReset{}
+		result := cognitoidentityprovider.ForgotPasswordOutput{}
+
+		response, err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
+
+		So(response, ShouldBeNil)
+		castErr := err.(*models.Error)
+		So(castErr.Code, ShouldEqual, models.InternalError)
+		So(castErr.Description, ShouldEqual, models.UnrecognisedCognitoResponseDescription)
+	})
+
+	Convey("returns a byte array of the response JSON", t, func() {
+		passwordResetParams := models.PasswordReset{}
+		result := cognitoidentityprovider.ForgotPasswordOutput{
+			CodeDeliveryDetails: nil,
+		}
+
+		response, err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
+
+		So(err, ShouldBeNil)
+		So(reflect.TypeOf(response), ShouldEqual, reflect.TypeOf([]byte{}))
+	})
+}

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -557,29 +557,3 @@ func TestPasswordReset_BuildCognitoRequest(t *testing.T) {
 		So(*response.ClientId, ShouldResemble, clientId)
 	})
 }
-
-func TestPasswordReset_BuildSuccessfulJsonResponse(t *testing.T) {
-	ctx := context.Background()
-
-	Convey("returns an InternalServerError if the Cognito response does not meet expected format", t, func() {
-		passwordResetParams := models.PasswordReset{}
-		result := cognitoidentityprovider.ForgotPasswordOutput{}
-
-		err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
-
-		castErr := err.(*models.Error)
-		So(castErr.Code, ShouldEqual, models.InternalError)
-		So(castErr.Description, ShouldEqual, models.UnrecognisedCognitoResponseDescription)
-	})
-
-	Convey("returns no error when given an expected Cognito response", t, func() {
-		passwordResetParams := models.PasswordReset{}
-		result := cognitoidentityprovider.ForgotPasswordOutput{
-			CodeDeliveryDetails: &cognitoidentityprovider.CodeDeliveryDetailsType{},
-		}
-
-		err := passwordResetParams.BuildSuccessfulJsonResponse(ctx, &result)
-
-		So(err, ShouldBeNil)
-	})
-}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -223,6 +223,38 @@ paths:
           description: "Requested unimplemented password change type"
           schema:
             $ref: '#/definitions/ErrorResponse'
+  /v1/password-reset:
+    put:
+      tags:
+        - Users
+      summary: "Sends the user a password reset email"
+      description: "Trigger a password reset email from Cognito"
+      consumes:
+        - application/json
+      produces:
+        - "application/json"
+      parameters:
+        - in: body
+          name: "Password reset params"
+          description: "The email address for the user resetting their password"
+          schema:
+            required: ["email"]
+            type: object
+            properties:
+              email:
+                type: string
+                example: "email@ons.gov.uk"
+      responses:
+        202:
+          description: "Request accepted"
+        400:
+          description: "Email was not in a valid format"
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        500:
+          description: "Invalid request body or unexpected Cognito response"
+          schema:
+            $ref: '#/definitions/ErrorResponse'
 
 
 responses:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -331,6 +331,7 @@ definitions:
           - "InvalidToken"
           - "InternalServerError"
           - "NotFound"
+          - "UserNotFound"
           - "AlreadyExists"
           - "DeliveryFailure"
           - "InvalidCode"

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"regexp"
+	"strings"
 )
 
 // This regex checks entered email address and if match found, email address deemed valid, else invalid.
@@ -51,7 +52,7 @@ func IsEmailValid(e string) bool {
 		return false
 	}
 
-	return emailRegex.MatchString(e)
+	return emailRegex.MatchString(strings.ToLower(e))
 }
 
 // ValidateONSEmail - validates email address for ons domain
@@ -60,7 +61,7 @@ func ValidateONSEmail(e string) bool {
 	if !emailLengthValid(len(e)) {
 		return false
 	}
-	return onsEmailRegex.MatchString(e)
+	return onsEmailRegex.MatchString(strings.ToLower(e))
 }
 
 func emailLengthValid(l int) bool {

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -25,6 +25,14 @@ func TestEmailValidationConformsToExpectedFormat(t *testing.T) {
 		So(emailResponse, ShouldBeTrue)
 	})
 
+	Convey("A capitalised email conforms to the expected format and is validated", t, func() {
+
+		email := "EMAIL.EMAIL@DOMAIN.HOST"
+
+		emailResponse := IsEmailValid(email)
+		So(emailResponse, ShouldBeTrue)
+	})
+
 	Convey("The empty email does not conform to the expected format and is validated", t, func() {
 
 		email := ""


### PR DESCRIPTION
### What

Added endpoint to handle requests for password reset emails 

### How to review

Ensure the unit and feature tests are passing.

*With a user created and confirmed within Cognito
- Send a POST request to '/v1/password-reset' - the body of the request should contain:
    - 'email': the email of the user
- You should receive a 202 response and an email with a verification code

- Send a POST request to '/v1/password-reset' - the body of the request should contain:
    - 'email': an email that does not relate to a user in Cognito
- You should receive a 202 response but no email

### Who can review

Anyone but me
