### PR TITLE
change constructor to accept one or more errors to make calls cleaner

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -125,16 +125,16 @@ func writeSuccessResponse(ctx context.Context, w http.ResponseWriter, successRes
 }
 
 func handleBodyReadError(ctx context.Context, err error) *models.ErrorResponse {
-	return models.NewErrorResponse([]error{models.NewError(ctx, err, models.BodyReadError, models.BodyReadFailedDescription)},
-		http.StatusInternalServerError,
+	return models.NewErrorResponse(http.StatusInternalServerError,
 		nil,
+		models.NewError(ctx, err, models.BodyReadError, models.BodyReadFailedDescription),
 	)
 }
 
 func handleBodyUnmarshalError(ctx context.Context, err error) *models.ErrorResponse {
-	return models.NewErrorResponse([]error{models.NewError(ctx, err, models.JSONUnmarshalError, models.ErrorUnmarshalFailedDescription)},
-		http.StatusInternalServerError,
+	return models.NewErrorResponse(http.StatusInternalServerError,
 		nil,
+		models.NewError(ctx, err, models.JSONUnmarshalError, models.ErrorUnmarshalFailedDescription),
 	)
 }
 

--- a/api/users.go
+++ b/api/users.go
@@ -29,7 +29,7 @@ func (api *API) CreateUserHandler(ctx context.Context, w http.ResponseWriter, re
 
 	err = user.GeneratePassword(ctx)
 	if err != nil {
-		return nil, models.NewErrorResponse([]error{err}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, err)
 	}
 
 	validationErrs := user.ValidateRegistration(ctx)
@@ -37,7 +37,7 @@ func (api *API) CreateUserHandler(ctx context.Context, w http.ResponseWriter, re
 	listUserInput := models.UsersList{}.BuildListUserRequest("email = \""+user.Email+"\"", "email", int64(1), &api.UserPoolId)
 	listUserResp, err := api.CognitoClient.ListUsers(listUserInput)
 	if err != nil {
-		return nil, models.NewErrorResponse([]error{models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint")}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint"))
 	}
 	duplicateEmailErr := user.CheckForDuplicateEmail(ctx, listUserResp)
 	if duplicateEmailErr != nil {
@@ -45,7 +45,7 @@ func (api *API) CreateUserHandler(ctx context.Context, w http.ResponseWriter, re
 	}
 
 	if len(validationErrs) != 0 {
-		return nil, models.NewErrorResponse(validationErrs, http.StatusBadRequest, nil)
+		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErrs...)
 	}
 
 	createUserRequest := user.BuildCreateUserRequest(uuid.NewString(), api.UserPoolId)
@@ -54,16 +54,16 @@ func (api *API) CreateUserHandler(ctx context.Context, w http.ResponseWriter, re
 	if err != nil {
 		responseErr := models.NewCognitoError(ctx, err, "AdminCreateUser request from create user endpoint")
 		if responseErr.Code == models.InternalError {
-			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 		} else {
-			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusBadRequest, nil)
+			return nil, models.NewErrorResponse(http.StatusBadRequest, nil, responseErr)
 		}
 	}
 
 	createdUser := models.UserParams{}.MapCognitoDetails(resultUser.User)
 	jsonResponse, responseErr := createdUser.BuildSuccessfulJsonResponse(ctx)
 	if responseErr != nil {
-		return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
 	return models.NewSuccessResponse(jsonResponse, http.StatusCreated, nil), nil
@@ -75,14 +75,14 @@ func (api *API) ListUsersHandler(ctx context.Context, w http.ResponseWriter, req
 	listUserInput := usersList.BuildListUserRequest("", "", int64(0), &api.UserPoolId)
 	listUserResp, err := api.CognitoClient.ListUsers(listUserInput)
 	if err != nil {
-		return nil, models.NewErrorResponse([]error{models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint")}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint"))
 	}
 
 	usersList.MapCognitoUsers(listUserResp)
 
 	jsonResponse, responseErr := usersList.BuildSuccessfulJsonResponse(ctx)
 	if responseErr != nil {
-		return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
@@ -97,9 +97,9 @@ func (api *API) GetUserHandler(ctx context.Context, w http.ResponseWriter, req *
 	if err != nil {
 		responseErr := models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint")
 		if responseErr.Code == models.UserNotFoundError {
-			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusNotFound, nil)
+			return nil, models.NewErrorResponse(http.StatusNotFound, nil, responseErr)
 		} else {
-			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 		}
 	}
 
@@ -107,7 +107,7 @@ func (api *API) GetUserHandler(ctx context.Context, w http.ResponseWriter, req *
 
 	jsonResponse, responseErr := user.BuildSuccessfulJsonResponse(ctx)
 	if responseErr != nil {
-		return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
@@ -133,7 +133,7 @@ func (api *API) UpdateUserHandler(ctx context.Context, w http.ResponseWriter, re
 	validationErrs := user.ValidateUpdate(ctx)
 
 	if len(validationErrs) != 0 {
-		return nil, models.NewErrorResponse(validationErrs, http.StatusBadRequest, nil)
+		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErrs...)
 	}
 
 	userRequest := user.BuildUpdateUserRequest(api.UserPoolId)
@@ -141,27 +141,26 @@ func (api *API) UpdateUserHandler(ctx context.Context, w http.ResponseWriter, re
 	_, err = api.CognitoClient.AdminUpdateUserAttributes(userRequest)
 	if err != nil {
 		responseErr := models.NewCognitoError(ctx, err, "AdminUpdateUserAttributes request from update user endpoint")
-		errList := []error{responseErr}
 		if responseErr.Code == models.UserNotFoundError {
-			return nil, models.NewErrorResponse(errList, http.StatusNotFound, nil)
+			return nil, models.NewErrorResponse(http.StatusNotFound, nil, responseErr)
 		} else if responseErr.Code == models.InvalidFieldError {
-			return nil, models.NewErrorResponse(errList, http.StatusBadRequest, nil)
+			return nil, models.NewErrorResponse(http.StatusBadRequest, nil, responseErr)
 		}
-		return nil, models.NewErrorResponse(errList, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
 	userDetailsRequest := user.BuildAdminGetUserRequest(api.UserPoolId)
 	userDetailsResponse, err := api.CognitoClient.AdminGetUser(userDetailsRequest)
 	if err != nil {
 		responseErr := models.NewCognitoError(ctx, err, "AdminGetUser request from update user endpoint")
-		return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
 	user.MapCognitoGetResponse(userDetailsResponse)
 
 	jsonResponse, responseErr := user.BuildSuccessfulJsonResponse(ctx)
 	if responseErr != nil {
-		return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
@@ -188,7 +187,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, w http.ResponseWriter
 	if changePasswordParams.ChangeType == models.NewPasswordRequiredType {
 		validationErrs := changePasswordParams.ValidateNewPasswordRequiredRequest(ctx)
 		if len(validationErrs) != 0 {
-			return nil, models.NewErrorResponse(validationErrs, http.StatusBadRequest, nil)
+			return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErrs...)
 		}
 
 		changePasswordRequest := changePasswordParams.BuildAuthChallengeResponseRequest(api.ClientSecret, api.ClientId, NewPasswordChallenge)
@@ -198,9 +197,9 @@ func (api *API) ChangePasswordHandler(ctx context.Context, w http.ResponseWriter
 		if cognitoErr != nil {
 			parsedErr := models.NewCognitoError(ctx, cognitoErr, "RespondToAuthChallenge request from change password endpoint")
 			if parsedErr.Code == models.InternalError {
-				return nil, models.NewErrorResponse([]error{parsedErr}, http.StatusInternalServerError, nil)
+				return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, parsedErr)
 			} else if parsedErr.Code == models.InvalidPasswordError || parsedErr.Code == models.InvalidCodeError {
-				return nil, models.NewErrorResponse([]error{parsedErr}, http.StatusBadRequest, nil)
+				return nil, models.NewErrorResponse(http.StatusBadRequest, nil, parsedErr)
 			}
 		} else {
 			jsonResponse, responseErr = changePasswordParams.BuildAuthChallengeSuccessfulJsonResponse(ctx, result)
@@ -216,7 +215,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, w http.ResponseWriter
 	} else if changePasswordParams.ChangeType == models.ForgottenPasswordType {
 		validationErrs := changePasswordParams.ValidateForgottenPasswordRequiredRequest(ctx)
 		if len(validationErrs) != 0 {
-			return nil, models.NewErrorResponse(validationErrs, http.StatusBadRequest, nil)
+			return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErrs...)
 		}
 		changeForgottenPasswordRequest := changePasswordParams.BuildConfirmForgotPasswordRequest(api.ClientSecret, api.ClientId)
 
@@ -225,19 +224,18 @@ func (api *API) ChangePasswordHandler(ctx context.Context, w http.ResponseWriter
 		if cognitoErr != nil {
 			parsedErr := models.NewCognitoError(ctx, cognitoErr, "ConfirmForgottenPassword request from change password endpoint")
 			if parsedErr.Code == models.InternalError {
-				return nil, models.NewErrorResponse([]error{parsedErr}, http.StatusInternalServerError, nil)
+				return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, parsedErr)
 			} else if parsedErr.Code == models.InvalidPasswordError || parsedErr.Code == models.InvalidCodeError {
-				return nil, models.NewErrorResponse([]error{parsedErr}, http.StatusBadRequest, nil)
+				return nil, models.NewErrorResponse(http.StatusBadRequest, nil, parsedErr)
 			}
 		}
-
 	} else {
 		err = models.NewValidationError(ctx, models.UnknownRequestTypeError, models.UnknownPasswordChangeTypeDescription)
-		return nil, models.NewErrorResponse([]error{err}, http.StatusBadRequest, nil)
+		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, err)
 	}
 
 	if responseErr != nil {
-		return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
 	return models.NewSuccessResponse(jsonResponse, http.StatusAccepted, headers), nil
@@ -261,7 +259,7 @@ func (api *API) PasswordResetHandler(ctx context.Context, w http.ResponseWriter,
 	validationErr := passwordResetParams.Validate(ctx)
 
 	if validationErr != nil {
-		return nil, models.NewErrorResponse([]error{validationErr}, http.StatusBadRequest, nil)
+		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErr)
 	}
 
 	forgotPasswordRequest := passwordResetParams.BuildCognitoRequest(api.ClientSecret, api.ClientId)
@@ -270,9 +268,9 @@ func (api *API) PasswordResetHandler(ctx context.Context, w http.ResponseWriter,
 	if err != nil {
 		responseErr := models.NewCognitoError(ctx, err, "ForgotPassword request from password reset endpoint")
 		if responseErr.Code == models.LimitExceededError || responseErr.Code == models.TooManyRequestsError {
-			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusBadRequest, nil)
+			return nil, models.NewErrorResponse(http.StatusBadRequest, nil, responseErr)
 		} else if responseErr.Code != models.UserNotFoundError && responseErr.Code != models.UserNotConfirmedError {
-			return nil, models.NewErrorResponse([]error{responseErr}, http.StatusInternalServerError, nil)
+			return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 		}
 	}
 

--- a/models/responses.go
+++ b/models/responses.go
@@ -1,29 +1,29 @@
 package models
 
 type ErrorResponse struct {
-	Errors []error            `json:"errors"`
-	Status int                `json:"-"`
+	Errors  []error           `json:"errors"`
+	Status  int               `json:"-"`
 	Headers map[string]string `json:"-"`
 }
 
-func NewErrorResponse(errors []error, statusCode int, headers map[string]string) *ErrorResponse {
+func NewErrorResponse(statusCode int, headers map[string]string, errors ...error) *ErrorResponse {
 	return &ErrorResponse{
-		Errors: errors,
-		Status: statusCode,
+		Errors:  errors,
+		Status:  statusCode,
 		Headers: headers,
 	}
 }
 
 type SuccessResponse struct {
-	Body   []byte `json:"-"`
-	Status int    `json:"-"`
+	Body    []byte            `json:"-"`
+	Status  int               `json:"-"`
 	Headers map[string]string `json:"-"`
 }
 
 func NewSuccessResponse(jsonBody []byte, statusCode int, headers map[string]string) *SuccessResponse {
 	return &SuccessResponse{
-		Body:   jsonBody,
-		Status: statusCode,
+		Body:    jsonBody,
+		Status:  statusCode,
 		Headers: headers,
 	}
 }

--- a/models/responses_test.go
+++ b/models/responses_test.go
@@ -12,17 +12,43 @@ import (
 
 func TestNewErrorResponse(t *testing.T) {
 	Convey("successfully constructs an ErrorResponse object", t, func() {
-		err := models.Error{
-			Cause:       errors.New("TestError"),
-			Code:        "TestErrorCode",
-			Description: "description of the error",
-		}
 
-		errResponse := models.NewErrorResponse([]error{&err}, http.StatusInternalServerError, nil)
+		Convey("with one error", func() {
+			err := models.Error{
+				Cause:       errors.New("TestError"),
+				Code:        "TestErrorCode",
+				Description: "description of the error",
+			}
 
-		So(errResponse, ShouldNotBeNil)
-		So(len(errResponse.Errors), ShouldEqual, 1)
-		So(errResponse.Status, ShouldEqual, http.StatusInternalServerError)
+			errResponse := models.NewErrorResponse(http.StatusInternalServerError, nil, &err)
+
+			So(errResponse, ShouldNotBeNil)
+			So(len(errResponse.Errors), ShouldEqual, 1)
+			So(errResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("with multiple errors", func() {
+			err := models.Error{
+				Cause:       errors.New("TestError"),
+				Code:        "TestErrorCode",
+				Description: "description of the error",
+			}
+			err2 := models.Error{
+				Cause:       errors.New("TestError2"),
+				Code:        "TestErrorCode",
+				Description: "description of the error",
+			}
+			errList := []error{
+				&err,
+				&err2,
+			}
+
+			errResponse := models.NewErrorResponse(http.StatusInternalServerError, nil, errList...)
+
+			So(errResponse, ShouldNotBeNil)
+			So(len(errResponse.Errors), ShouldEqual, 2)
+			So(errResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		})
 	})
 }
 


### PR DESCRIPTION
### What

Refactor the ErrorResponse constructor to accept one or more errors, rather than a list, to make function calls cleaner when there is only one error.

### How to review

Ensure all unit and component tests are still passing.

### Who can review

Anyone but me
