### PR TITLE
Feature/configurable email validation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -29,6 +29,7 @@ type API struct {
 	ClientId       string
 	ClientSecret   string
 	ClientAuthFlow string
+	AllowedDomains []string
 }
 
 type baseHandler func(ctx context.Context, w http.ResponseWriter, r *http.Request) (*models.SuccessResponse, *models.ErrorResponse)
@@ -46,10 +47,10 @@ func contextAndErrors(h baseHandler) http.HandlerFunc {
 }
 
 //Setup function sets up the api and returns an api
-func Setup(ctx context.Context, r *mux.Router, cognitoClient cognito.Client, userPoolId string, clientId string, clientSecret string, clientAuthFlow string) (*API, error) {
+func Setup(ctx context.Context, r *mux.Router, cognitoClient cognito.Client, userPoolId string, clientId string, clientSecret string, clientAuthFlow string, allowedDomains []string) (*API, error) {
 
 	// Return an error if empty required parameter was passed.
-	if userPoolId == "" || clientId == "" || clientSecret == "" || clientAuthFlow == "" {
+	if userPoolId == "" || clientId == "" || clientSecret == "" || clientAuthFlow == "" || allowedDomains == nil || len(allowedDomains) == 0 {
 		return nil, models.NewError(ctx, nil, models.MissingConfigError, models.MissingConfigDescription)
 	}
 
@@ -64,6 +65,7 @@ func Setup(ctx context.Context, r *mux.Router, cognitoClient cognito.Client, use
 		ClientId:       clientId,
 		ClientSecret:   clientSecret,
 		ClientAuthFlow: clientAuthFlow,
+		AllowedDomains: allowedDomains,
 	}
 
 	r.HandleFunc("/v1/tokens", contextAndErrors(api.TokensHandler)).Methods(http.MethodPost)

--- a/api/users.go
+++ b/api/users.go
@@ -32,7 +32,7 @@ func (api *API) CreateUserHandler(ctx context.Context, w http.ResponseWriter, re
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, err)
 	}
 
-	validationErrs := user.ValidateRegistration(ctx)
+	validationErrs := user.ValidateRegistration(ctx, api.AllowedDomains)
 
 	listUserInput := models.UsersList{}.BuildListUserRequest("email = \""+user.Email+"\"", "email", int64(1), &api.UserPoolId)
 	listUserResp, err := api.CognitoClient.ListUsers(listUserInput)

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -220,7 +220,6 @@ func TestCreateUserHandler(t *testing.T) {
 
 			So(successResponse, ShouldBeNil)
 			So(errorResponse.Status, ShouldEqual, tt.httpResponse)
-			//So(len(errorResponse.Errors), ShouldEqual, len(tt.errorCodes))
 			castErr := errorResponse.Errors[0].(*models.Error)
 			So(castErr.Code, ShouldEqual, tt.errorCodes[0])
 			if len(errorResponse.Errors) > 1 {

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	AWSCognitoClientId         string        `envconfig:"AWS_COGNITO_CLIENT_ID" json:"-"`
 	AWSCognitoClientSecret     string        `envconfig:"AWS_COGNITO_CLIENT_SECRET" json:"-"`
 	AWSAuthFlow                string        `envconfig:"AWS_AUTH_FLOW" json:"-"`
+	AllowedEmailDomains        []string      `envconfig:"ALLOWED_EMAIL_DOMAINS" json:"-"`
 }
 
 var cfg *Config
@@ -36,6 +37,7 @@ func Get() (*Config, error) {
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		AWSRegion:                  "eu-west-1",
 		AWSAuthFlow:                "USER_PASSWORD_AUTH",
+		AllowedEmailDomains:        []string{"@ons.gov.uk"},
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ func Get() (*Config, error) {
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		AWSRegion:                  "eu-west-1",
 		AWSAuthFlow:                "USER_PASSWORD_AUTH",
-		AllowedEmailDomains:        []string{"@ons.gov.uk"},
+		AllowedEmailDomains:        []string{"@ons.gov.uk", "@ext.ons.gov.uk"},
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ func TestConfig(t *testing.T) {
 					HealthCheckCriticalTimeout: 90 * time.Second,
 					AWSRegion:                  "eu-west-1",
 					AWSAuthFlow:                "USER_PASSWORD_AUTH",
+					AllowedEmailDomains:        []string{"@ons.gov.uk", "@ext.ons.gov.uk"},
 				})
 			})
 

--- a/models/users.go
+++ b/models/users.go
@@ -85,7 +85,7 @@ func (p *UserParams) GeneratePassword(ctx context.Context) error {
 }
 
 //ValidateRegistration validates the required fields for user creation, returning validation errors for any failures
-func (p UserParams) ValidateRegistration(ctx context.Context) []error {
+func (p UserParams) ValidateRegistration(ctx context.Context, allowedDomains []string) []error {
 	var validationErrs []error
 	if p.Forename == "" {
 		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidForenameError, InvalidForenameErrorDescription))
@@ -95,7 +95,7 @@ func (p UserParams) ValidateRegistration(ctx context.Context) []error {
 		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidSurnameError, InvalidSurnameErrorDescription))
 	}
 
-	if !validation.ValidateONSEmail(p.Email) {
+	if !validation.IsAllowedEmailDomain(p.Email, allowedDomains) {
 		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidEmailError, InvalidEmailDescription))
 	}
 	return validationErrs

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -110,6 +110,7 @@ func TestUserParams_GeneratePassword(t *testing.T) {
 
 func TestUserParams_ValidateRegistration(t *testing.T) {
 	ctx := context.Background()
+	allowedDomains := []string{"@ons.gov.uk", "@ext.ons.gov.uk"}
 
 	Convey("returns an InvalidForename error if an invalid forename is submitted", t, func() {
 		user := models.UserParams{
@@ -118,7 +119,7 @@ func TestUserParams_ValidateRegistration(t *testing.T) {
 			Lastname: "Smith",
 		}
 
-		errs := user.ValidateRegistration(ctx)
+		errs := user.ValidateRegistration(ctx, allowedDomains)
 
 		So(len(errs), ShouldEqual, 1)
 		castErr := errs[0].(*models.Error)
@@ -133,7 +134,7 @@ func TestUserParams_ValidateRegistration(t *testing.T) {
 			Lastname: "",
 		}
 
-		errs := user.ValidateRegistration(ctx)
+		errs := user.ValidateRegistration(ctx, allowedDomains)
 
 		So(len(errs), ShouldEqual, 1)
 		castErr := errs[0].(*models.Error)
@@ -148,7 +149,7 @@ func TestUserParams_ValidateRegistration(t *testing.T) {
 			Lastname: "Smith",
 		}
 
-		errs := user.ValidateRegistration(ctx)
+		errs := user.ValidateRegistration(ctx, allowedDomains)
 
 		So(len(errs), ShouldEqual, 1)
 		castErr := errs[0].(*models.Error)
@@ -163,7 +164,7 @@ func TestUserParams_ValidateRegistration(t *testing.T) {
 			Lastname: "Smith",
 		}
 
-		errs := user.ValidateRegistration(ctx)
+		errs := user.ValidateRegistration(ctx, allowedDomains)
 
 		So(len(errs), ShouldEqual, 1)
 		castErr := errs[0].(*models.Error)

--- a/service/service.go
+++ b/service/service.go
@@ -35,7 +35,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	cognitoclient := serviceList.GetCognitoClient(cfg.AWSRegion)
 
-	a, err := api.Setup(ctx, r, cognitoclient, cfg.AWSCognitoUserPoolID, cfg.AWSCognitoClientId, cfg.AWSCognitoClientSecret, cfg.AWSAuthFlow)
+	a, err := api.Setup(ctx, r, cognitoclient, cfg.AWSCognitoUserPoolID, cfg.AWSCognitoClientId, cfg.AWSCognitoClientSecret, cfg.AWSAuthFlow, cfg.AllowedEmailDomains)
 	if err != nil {
 		log.Event(ctx, "error returned from api setup", log.FATAL, log.Error(err))
 		return nil, err

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -55,9 +55,8 @@ func IsEmailValid(e string) bool {
 	return emailRegex.MatchString(strings.ToLower(e))
 }
 
-// ValidateONSEmail - validates email address for ons domain
-// valid if match found, else invalid
-func ValidateONSEmail(e string) bool {
+// IsAllowedEmailDomain - validates email address is a valid email format and the domain is in the allowed list in config
+func IsAllowedEmailDomain(e string, allowedDomains []string) bool {
 	if !emailLengthValid(len(e)) {
 		return false
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -41,7 +41,6 @@ import (
 // .my.name@myself.com - match not found - invalid
 // my.name@myself.com. - match not found - invalid
 var emailRegex = regexp.MustCompile(`^(?:[a-z0-9!#$%&'*+/=?^_` + "`" + `{|}~-]+(?:\.[a-z0-9-!#$%&'*+/=?^_` + "`" + `{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)$`)
-var onsEmailRegex = regexp.MustCompile(`^(?:[a-z0-9!#$%&'*+/=?^_` + "`" + `{|}~-]+(?:\.[a-z0-9-!#$%&'*+/=?^_` + "`" + `{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(:?ext\.)?ons.gov.uk$`)
 var (
 	minimumEmailLength, maximumEmailLength int = 3, 254
 )

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -56,11 +56,16 @@ func IsEmailValid(e string) bool {
 }
 
 // IsAllowedEmailDomain - validates email address is a valid email format and the domain is in the allowed list in config
-func IsAllowedEmailDomain(e string, allowedDomains []string) bool {
-	if !emailLengthValid(len(e)) {
-		return false
+func IsAllowedEmailDomain(email string, allowedDomains []string) bool {
+	if isValidStructure := IsEmailValid(email); !isValidStructure {
+		return isValidStructure
 	}
-	return onsEmailRegex.MatchString(strings.ToLower(e))
+	for _, domain := range allowedDomains {
+		if strings.HasSuffix(email, domain) {
+			return true
+		}
+	}
+	return false
 }
 
 func emailLengthValid(l int) bool {

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -106,6 +106,12 @@ func TestEmailDomainValidationCorrectlyValidatesAllowedDomains(t *testing.T) {
 		So(emailResponse, ShouldBeFalse)
 	})
 
+	Convey("The allowed domain is only part of the domain so it is not validated", t, func() {
+		email := "email.email@ons.gov.uk.test.com"
+		emailResponse := IsAllowedEmailDomain(email, allowedDomains)
+		So(emailResponse, ShouldBeFalse)
+	})
+
 	Convey("The email conforms to the expected format and is an allowed domain then it is validated", t, func() {
 		email := "email.email@ons.gov.uk"
 		emailResponse := IsAllowedEmailDomain(email, allowedDomains)

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -84,3 +84,46 @@ func TestEmailValidationConformsToExpectedFormat(t *testing.T) {
 	})
 
 }
+
+func TestEmailDomainValidationCorrectlyValidatesAllowedDomains(t *testing.T) {
+	allowedDomains := []string{"@ons.gov.uk", "@ext.ons.gov.uk"}
+
+	Convey("An empty email does not conform to the expected format and is not validated", t, func() {
+		email := ""
+		emailResponse := IsAllowedEmailDomain(email, allowedDomains)
+		So(emailResponse, ShouldBeFalse)
+	})
+
+	Convey("A badly formatted email is not validated", t, func() {
+		email := "string@string@string.string"
+		emailResponse := IsAllowedEmailDomain(email, allowedDomains)
+		So(emailResponse, ShouldBeFalse)
+	})
+
+	Convey("The email conforms to the expected format but is not an allowed domain so it is not validated", t, func() {
+		email := "email.email@gmail.com"
+		emailResponse := IsAllowedEmailDomain(email, allowedDomains)
+		So(emailResponse, ShouldBeFalse)
+	})
+
+	Convey("The email conforms to the expected format and is an allowed domain then it is validated", t, func() {
+		email := "email.email@ons.gov.uk"
+		emailResponse := IsAllowedEmailDomain(email, allowedDomains)
+		So(emailResponse, ShouldBeTrue)
+
+		email = "email.email@ext.ons.gov.uk"
+		emailResponse = IsAllowedEmailDomain(email, allowedDomains)
+		So(emailResponse, ShouldBeTrue)
+	})
+
+	Convey("A new domain is added to the allowed list, emails using it are now validated", t, func() {
+		email := "email.email@gmail.com"
+		emailResponse := IsAllowedEmailDomain(email, allowedDomains)
+		So(emailResponse, ShouldBeFalse)
+
+		newAllowedDomains := append(allowedDomains, "@gmail.com")
+
+		emailResponse = IsAllowedEmailDomain(email, newAllowedDomains)
+		So(emailResponse, ShouldBeTrue)
+	})
+}


### PR DESCRIPTION
### What

Made the allowed domains used to verify email address of new users a config attribute, so it can be set differently in different environments

### How to review

Ensure all unit and feature tests are still passing and the services runs.
Send a POST request to /v1/users with body:
{
    "forename": "J",
    "lastname": "Doe",
    "email":  (any non ons.gov.uk or ext.ons.gov.uk email address)
}
You should receive a 400 response with an InvalidEmail error.

Locally set the env variable ALLOWED_EMAIL_DOMAINS as the domain of your non ons email address.
Restart the service and resend the request from above.

You should receive a 201 response this time.

### Who can review

Anyone but me
