### PR TITLE
Bug/list all users

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/ONSdigital/dp-identity-api/models"
 
@@ -19,6 +20,11 @@ var (
 	ONSRealm               = "Florence publishing platform"
 	Charset                = "UTF-8"
 	NewPasswordChallenge   = "NEW_PASSWORD_REQUIRED"
+	DefaultBackOffSchedule = []time.Duration{
+		1 * time.Second,
+		3 * time.Second,
+		10 * time.Second,
+	}
 )
 
 //API provides a struct to wrap the api around

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -159,19 +159,14 @@ func (api *API) RefreshHandler(ctx context.Context, w http.ResponseWriter, req *
 func (api *API) SignOutAllUsersHandler(ctx context.Context, w http.ResponseWriter, req *http.Request) (*models.SuccessResponse, *models.ErrorResponse) {
 	var (
 		userFilterString string = "status=\"Enabled\""
-		backOff                 = []time.Duration{
-			1 * time.Second,
-			3 * time.Second,
-			10 * time.Second,
-		}
 	)
-	usersList, awsErr := api.ListUsersWorker(req.Context(), &userFilterString, backOff)
+	usersList, awsErr := api.ListUsersWorker(req.Context(), &userFilterString, DefaultBackOffSchedule)
 	if awsErr != nil {
 		return nil, awsErr
 	}
 	globalSignOut := &models.GlobalSignOut{
 		ResultsChannel:  make(chan string, len(*usersList)),
-		BackoffSchedule: backOff,
+		BackoffSchedule: DefaultBackOffSchedule,
 		RetryAllowed:    true,
 	}
 	// run api.SignOutUsersWorker concurrently

--- a/api/users.go
+++ b/api/users.go
@@ -77,13 +77,13 @@ func (api *API) CreateUserHandler(ctx context.Context, w http.ResponseWriter, re
 //ListUsersHandler lists the users in the user pool
 func (api *API) ListUsersHandler(ctx context.Context, w http.ResponseWriter, req *http.Request) (*models.SuccessResponse, *models.ErrorResponse) {
 	usersList := models.UsersList{}
-	listUserInput := usersList.BuildListUserRequest("", "", int64(0), nil, &api.UserPoolId)
-	listUserResp, err := api.CognitoClient.ListUsers(listUserInput)
-	if err != nil {
-		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint"))
+
+	listUserResp, errResponse := api.ListUsersWorker(req.Context(), aws.String(""), DefaultBackOffSchedule)
+	if errResponse != nil {
+		return nil, errResponse
 	}
 
-	usersList.MapCognitoUsers(&listUserResp.Users)
+	usersList.SetUsers(listUserResp)
 
 	jsonResponse, responseErr := usersList.BuildSuccessfulJsonResponse(ctx)
 	if responseErr != nil {

--- a/cognito/mock/user_mocker.go
+++ b/cognito/mock/user_mocker.go
@@ -25,6 +25,13 @@ func (m *CognitoIdentityProviderClientStub) AddUserWithUsername(username, email 
 	m.Users = append(m.Users, m.GenerateUser(username, email, "", "", "", isConfirmed))
 }
 
+//Generates the required number of users in the system
+func (m *CognitoIdentityProviderClientStub) AddMultipleUsers(usersCount int) {
+	for len(m.Users) < usersCount {
+		m.Users = append(m.Users, m.GenerateUser("", "", "", "", "", true))
+	}
+}
+
 func (m *CognitoIdentityProviderClientStub) GenerateUser(id, email, password, givenName, familyName string, isConfirmed bool) *User {
 	statusString := "FORCE_CHANGE_PASSWORD"
 	if isConfirmed {
@@ -82,18 +89,18 @@ func BulkGenerateUsers(userCount int, userNames []string) *cognitoidentityprovid
 	paginationToken := "abc-123-xyz-345-xxx"
 	usersList := &cognitoidentityprovider.ListUsersOutput{}
 	for i := 0; i < userCount; i++ {
-		var(
+		var (
 			userId, status string = "", "CONFIRMED"
-			enabled bool = true
+			enabled        bool   = true
 		)
 		if userNames == nil || i > len(userNames)-1 {
 			userId = uuid.NewString()
 		} else {
 			userId = userNames[i]
 		}
-		user            := &cognitoidentityprovider.UserType{}
-		user.Username   = &userId
-		user.Enabled    = &enabled
+		user := &cognitoidentityprovider.UserType{}
+		user.Username = &userId
+		user.Enabled = &enabled
 		user.UserStatus = &status
 		usersList.Users = append(usersList.Users, user)
 		usersList.PaginationToken = &paginationToken

--- a/features/users.feature
+++ b/features/users.feature
@@ -210,6 +210,12 @@ Feature: Users
             }
             """
 
+    Scenario: GET /v1/users with more than 60 users and checking the response status 200 with the correct number of users
+        Given there are "70" users in the database
+        When I GET "/v1/users"
+        Then the HTTP status code should be "200"
+        And the list response should contain "70" entries
+
     Scenario: GET /v1/users unexpected server error and checking the response status 500
         Given a user with email "internal.error@ons.gov.uk" and password "Passw0rd!" exists in the database
         When I GET "/v1/users"

--- a/models/users.go
+++ b/models/users.go
@@ -18,8 +18,8 @@ const (
 )
 
 type UsersList struct {
-	Users []UserParams `json:"users"`
-	Count int          `json:"count"`
+	Users           []UserParams `json:"users"`
+	Count           int          `json:"count"`
 	PaginationToken string
 }
 
@@ -52,6 +52,12 @@ func (p *UsersList) MapCognitoUsers(cognitoResults *[]*cognitoidentityprovider.U
 	for _, user := range *cognitoResults {
 		p.Users = append(p.Users, UserParams{}.MapCognitoDetails(user))
 	}
+	p.Count = len(p.Users)
+}
+
+//SetUsers sets the UsersList Users attribute and sets the Count attribute
+func (p *UsersList) SetUsers(usersList *[]UserParams) {
+	p.Users = *usersList
 	p.Count = len(p.Users)
 }
 

--- a/models/users.go
+++ b/models/users.go
@@ -18,8 +18,8 @@ const (
 )
 
 type UsersList struct {
-	Users           []UserParams `json:"users"`
 	Count           int          `json:"count"`
+	Users           []UserParams `json:"users"`
 	PaginationToken string
 }
 

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -64,6 +64,36 @@ func TestUsersList_MapCognitoUsers(t *testing.T) {
 	})
 }
 
+func TestUsersList_SetUsers(t *testing.T) {
+	Convey("adds the supplied users to the users attribute and sets the count", t, func() {
+		listOfUsers := []models.UserParams{
+			{
+				Forename:    "Jane",
+				Lastname:    "Doe",
+				Email:       "jane.doe@ons.gov.uk",
+				Status:      "Confirmed",
+				Active:      true,
+				ID:          "user-1",
+				StatusNotes: "",
+			},
+			{
+				Forename:    "John",
+				Lastname:    "Doe",
+				Email:       "john.doe@ons.gov.uk",
+				Status:      "Confirmed",
+				Active:      true,
+				ID:          "user-2",
+				StatusNotes: "",
+			},
+		}
+		userList := models.UsersList{}
+		userList.SetUsers(&listOfUsers)
+
+		So(len(userList.Users), ShouldEqual, len(listOfUsers))
+		So(userList.Count, ShouldEqual, len(listOfUsers))
+	})
+}
+
 func TestUsersList_BuildSuccessfulJsonResponse(t *testing.T) {
 	Convey("returns a byte array of the response JSON", t, func() {
 		ctx := context.Background()


### PR DESCRIPTION
### What

Iterate through Cognito pagination responses to load all users in the list users endpoint rather than the 60 limited to a single Cognito response

### How to review

Ensure all unit and feature tests are passing.

Call GET /v1/users, you should receive a 200 response with a body that contains a list of users and a count higher than 60.
(Assuming there are more than 60 users in the local user pool, which there are at the time of writing)

### Who can review

Anyone but me
