### PR TITLE
refactor password reset validation to support user ids instead of emails

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -242,7 +242,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, w http.ResponseWriter
 			}
 		}
 	} else if changePasswordParams.ChangeType == models.ForgottenPasswordType {
-		validationErrs := changePasswordParams.ValidateForgottenPasswordRequiredRequest(ctx)
+		validationErrs := changePasswordParams.ValidateForgottenPasswordRequest(ctx)
 		if len(validationErrs) != 0 {
 			return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErrs...)
 		}

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -950,7 +950,7 @@ func TestConfirmForgotPasswordChangePasswordHandler(t *testing.T) {
 			// missing a change request param
 			{
 				map[string]interface{}{"type": models.ForgottenPasswordType, "email": "", "password": password, "verification_token": verificationToken},
-				models.InvalidEmailError,
+				models.InvalidUserIdError,
 				http.StatusBadRequest,
 			},
 		}

--- a/features/users.feature
+++ b/features/users.feature
@@ -1079,8 +1079,8 @@ Feature: Users
             {
                 "errors": [
                     {
-                        "code": "InvalidEmail",
-                        "description": "the submitted email could not be validated"
+                        "code": "InvalidUserId",
+                        "description": "the user id was missing"
                     }
                 ]
             }
@@ -1152,8 +1152,8 @@ Feature: Users
                         "description": "the submitted password could not be validated"
                     },
                     {
-                        "code": "InvalidEmail",
-                        "description": "the submitted email could not be validated"
+                        "code": "InvalidUserId",
+                        "description": "the user id was missing"
                     }
                 ]
             }
@@ -1175,8 +1175,8 @@ Feature: Users
             {
                 "errors": [
                     {
-                        "code": "InvalidEmail",
-                        "description": "the submitted email could not be validated"
+                        "code": "InvalidUserId",
+                        "description": "the user id was missing"
                     },
                     {
                         "code": "InvalidToken",
@@ -1206,8 +1206,8 @@ Feature: Users
                         "description": "the submitted password could not be validated"
                     },
                     {
-                        "code": "InvalidEmail",
-                        "description": "the submitted email could not be validated"
+                        "code": "InvalidUserId",
+                        "description": "the user id was missing"
                     },
                     {
                         "code": "InvalidToken",

--- a/models/users.go
+++ b/models/users.go
@@ -352,7 +352,7 @@ func (p *UserSignIn) BuildSuccessfulJsonResponse(ctx context.Context, result *co
 	if result.AuthenticationResult != nil {
 		tokenDuration := time.Duration(*result.AuthenticationResult.ExpiresIn)
 		expirationTime := time.Now().UTC().Add(time.Second * tokenDuration).String()
-		refreshTokenDuration := time.Duration(SecondsInDay*refreshTokenTTL)
+		refreshTokenDuration := time.Duration(SecondsInDay * refreshTokenTTL)
 		refreshTokenExpirationTime := time.Now().UTC().Add(time.Second * refreshTokenDuration).String()
 
 		postBody := map[string]interface{}{"expirationTime": expirationTime, "refreshTokenExpirationTime": refreshTokenExpirationTime}
@@ -437,13 +437,14 @@ func (p ChangePassword) BuildAuthChallengeSuccessfulJsonResponse(ctx context.Con
 	}
 }
 
-func (p ChangePassword) ValidateForgottenPasswordRequiredRequest(ctx context.Context) []error {
+func (p ChangePassword) ValidateForgottenPasswordRequest(ctx context.Context) []error {
 	var validationErrs []error
 	if !validation.IsPasswordValid(p.NewPassword) {
 		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidPasswordError, InvalidPasswordDescription))
 	}
-	if !validation.IsEmailValid(p.Email) {
-		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidEmailError, InvalidEmailDescription))
+	// 'Email' in the forgotten password request is actually the user id, so we are only checking for presence rather than format
+	if p.Email == "" {
+		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidUserIdError, MissingUserIdErrorDescription))
 	}
 	if p.VerificationToken == "" {
 		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidTokenError, InvalidTokenDescription))

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -856,7 +856,7 @@ func TestChangePassword_BuildAuthChallengeSuccessfulJsonResponse(t *testing.T) {
 	})
 }
 
-func TestChangePassword_ValidateForgottenPasswordRequiredRequest(t *testing.T) {
+func TestChangePassword_ValidateForgottenPasswordRequest(t *testing.T) {
 	ctx := context.Background()
 
 	Convey("returns validation errors if required parameters are missing", t, func() {
@@ -878,7 +878,7 @@ func TestChangePassword_ValidateForgottenPasswordRequiredRequest(t *testing.T) {
 				"≈",
 				"",
 				"Password2",
-				[]string{models.InvalidEmailError},
+				[]string{models.InvalidUserIdError},
 			},
 			{
 				// missing password
@@ -892,7 +892,7 @@ func TestChangePassword_ValidateForgottenPasswordRequiredRequest(t *testing.T) {
 				"",
 				"",
 				"Password2",
-				[]string{models.InvalidEmailError, models.InvalidTokenError},
+				[]string{models.InvalidUserIdError, models.InvalidTokenError},
 			},
 			{
 				// missing VerificationToken and password
@@ -906,14 +906,14 @@ func TestChangePassword_ValidateForgottenPasswordRequiredRequest(t *testing.T) {
 				"verification_token",
 				"",
 				"",
-				[]string{models.InvalidPasswordError, models.InvalidEmailError},
+				[]string{models.InvalidPasswordError, models.InvalidUserIdError},
 			},
 			{
 				// missing VerificationToken, email and password
 				"",
 				"",
 				"",
-				[]string{models.InvalidPasswordError, models.InvalidEmailError, models.InvalidTokenError},
+				[]string{models.InvalidPasswordError, models.InvalidUserIdError, models.InvalidTokenError},
 			},
 		}
 		for _, tt := range missingParamsTests {
@@ -924,7 +924,7 @@ func TestChangePassword_ValidateForgottenPasswordRequiredRequest(t *testing.T) {
 				NewPassword:       tt.Password,
 			}
 
-			validationErrs := passwordChangeParams.ValidateForgottenPasswordRequiredRequest(ctx)
+			validationErrs := passwordChangeParams.ValidateForgottenPasswordRequest(ctx)
 
 			So(len(validationErrs), ShouldEqual, len(tt.ExpectedErrors))
 			for i, expectedErrCode := range tt.ExpectedErrors {


### PR DESCRIPTION
### What

Refactored the forgotten password validation to support user ids rather than email addresses

### How to review

Ensure all unit and feature tests are passing and review the code change

### Who can review

Anyone but me
