### PR TITLE
Get single query argument for filter rather than whole query

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -89,8 +90,9 @@ func (api *API) ListUsersHandler(ctx context.Context, w http.ResponseWriter, req
 
 	usersList := models.UsersList{}
 
-	if req.URL.RawQuery != "" {
-		*filterString, validationErrs = api.GetFilterStringAndValidate(req.URL.Path, req.URL.RawQuery)
+	if req.URL.Query().Get("active") != "" {
+		queryStr := fmt.Sprintf("%s%s", "active=", req.URL.Query().Get("active"))
+		*filterString, validationErrs = api.GetFilterStringAndValidate(req.URL.Path, queryStr)
 		if validationErrs != nil {
 			return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErrs)
 		}


### PR DESCRIPTION
### What

This used to only work if the query part of the URL only had exactly `active=true` or `active=false` if there was a second query parameter or even a tailing `&` it would fall over. This is because it gets the raw query string (everything after the first `?`) and passes that to the filter function which looks for exactly one of the two mentioned above. 

This change makes it look for the exact query parameter it is expecting. This should allow it to be expanded on in the future and allow Florence to make use of this endpoint with the query parameter for filtering.

As it stand requests going through 
### How to review

Check that this is the correct fix
Check the code is clean

### Who can review

Someone who has been working on the Auth work (team 404)