### PR TITLE
Fix groups endpoint permissions

### DIFF
--- a/api/groups.go
+++ b/api/groups.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	GroupsCreatePermission string = "users:create"
-	GroupsReadPermission          = "users:read"
-	GroupsEditPermission        = "users:update"
-	GroupsDeletePermission        = "users:update"
+	GroupsCreatePermission = "groups:create"
+	GroupsReadPermission   = "groups:read"
+	GroupsEditPermission   = "groups:update"
+	GroupsDeletePermission = "groups:delete"
 )
 
 //CreateGroupHandler creates a new group

--- a/features/steps/identity_component.go
+++ b/features/steps/identity_component.go
@@ -125,7 +125,7 @@ func getPermissionsBundle() *permissions.Bundle {
 				},
 			},
 		},
-		"groups:edit": { // role
+		"groups:update": { // role
 			"groups/role-admin": { // group
 				{
 					ID: "2", // policy


### PR DESCRIPTION
### What

The group endpoints were using the `users:*` permissions rather than the
`groups:*` permissions.

### How to review

Ensure the permissions are correct.

### Who can review

!me
