### PR TITLE
Remove JWT authentication from password change endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -112,7 +112,7 @@ func Setup(ctx context.Context,
 		Methods(http.MethodGet)
 	// self used in paths rather than identifier as the identifier is a Cognito Session string in change password requests
 	// the user id is not yet available from the previous responses
-	r.HandleFunc("/v1/users/self/password", auth.Require(UsersUpdatePermission, contextAndErrors(api.ChangePasswordHandler))).
+	r.HandleFunc("/v1/users/self/password", contextAndErrors(api.ChangePasswordHandler)).
 		Methods(http.MethodPut)
 	r.HandleFunc("/v1/password-reset", contextAndErrors(api.PasswordResetHandler)).
 		Methods(http.MethodPost)

--- a/features/users.feature
+++ b/features/users.feature
@@ -760,17 +760,6 @@ Feature: Users
         And the response header "ID" should be "idToken"
         And the response header "Refresh" should be "refreshToken"
 
-    Scenario: PUT /v1/users/self/password without a JWT token and checking the response status 403
-        When I PUT "/v1/users/self/password"
-        """"""
-        Then the HTTP status code should be "403"
-
-    Scenario: PUT /v1/users/self/password as a publisher user and checking the response status 403
-        Given I am a publisher user
-        When I PUT "/v1/users/self/password"
-        """"""
-        Then the HTTP status code should be "403"
-
     Scenario: PUT /v1/users/self/password missing type and checking the response status 400
         Given a user with email "email@ons.gov.uk" and password "Passw0rd!" exists in the database
         And I am an admin user


### PR DESCRIPTION
### What

The password change endpoint uses either a single use password reset
token or a single use session token in the body to authenticate the
request rather than the standard JWT token header. As such the extra
auth middleware was resulting in a 403 response and blocking the ability
to set the password.

### How to review

Ensure the changes look valid.

### Who can review

!me