### PR TITLE
Add permanent password flag to user import script

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -61,7 +61,7 @@ func (api *API) CreateUserHandler(ctx context.Context, w http.ResponseWriter, re
 		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, validationErrs...)
 	}
 
-	createUserRequest := user.BuildCreateUserRequest(uuid.NewString(), api.UserPoolId)
+	createUserRequest := user.BuildCreateUserRequest(uuid.NewString(), api.UserPoolId, "")
 
 	resultUser, err := api.CognitoClient.AdminCreateUser(createUserRequest)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	"time"
+
+	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -21,7 +22,6 @@ type Config struct {
 	AWSAuthFlow                string        `envconfig:"AWS_AUTH_FLOW" json:"-"`
 	AllowedEmailDomains        []string      `envconfig:"ALLOWED_EMAIL_DOMAINS" json:"-"`
 	AuthorisationConfig        *authorisation.Config
-	MessageAction              string `envconfig:"MESSAGE_ACTION" json:"-"`
 }
 
 var cfg *Config
@@ -42,7 +42,6 @@ func Get() (*Config, error) {
 		AWSAuthFlow:                "USER_PASSWORD_AUTH",
 		AllowedEmailDomains:        []string{"@ons.gov.uk", "@ext.ons.gov.uk"},
 		AuthorisationConfig:        authorisation.NewDefaultConfig(),
-		MessageAction:              "",
 	}
 
 	return cfg, envconfig.Process("", cfg)
@@ -53,9 +52,4 @@ func Get() (*Config, error) {
 func (config Config) String() string {
 	configJson, _ := json.Marshal(config)
 	return string(configJson)
-}
-
-func GetMessageAction() string {
-	c, _ := Get()
-	return c.MessageAction
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -33,7 +34,6 @@ func TestConfig(t *testing.T) {
 					AWSAuthFlow:                "USER_PASSWORD_AUTH",
 					AllowedEmailDomains:        []string{"@ons.gov.uk", "@ext.ons.gov.uk"},
 					AuthorisationConfig:        authorisation.NewDefaultConfig(),
-					MessageAction:              "",
 				})
 			})
 

--- a/models/users.go
+++ b/models/users.go
@@ -3,7 +3,6 @@ package models
 import (
 	"context"
 	"encoding/json"
-	"github.com/ONSdigital/dp-identity-api/config"
 	"time"
 
 	"github.com/ONSdigital/dp-identity-api/utilities"
@@ -159,9 +158,9 @@ func (p UserParams) CheckForDuplicateEmail(ctx context.Context, listUserResp *co
 }
 
 //BuildCreateUserRequest generates a AdminCreateUserInput for Cognito
-func (p UserParams) BuildCreateUserRequest(userId string, userPoolId string) *cognitoidentityprovider.AdminCreateUserInput {
+func (p UserParams) BuildCreateUserRequest(userId, userPoolId, messageAction string) *cognitoidentityprovider.AdminCreateUserInput {
 	var (
-		deliveryMethod, messageAction, forenameAttrName, surnameAttrName, emailAttrName, emailVerifiedAttrName, emailVerifiedValue string = "EMAIL", config.GetMessageAction(), "given_name", "family_name", "email", "email_verified", "true"
+		deliveryMethod, forenameAttrName, surnameAttrName, emailAttrName, emailVerifiedAttrName, emailVerifiedValue string = "EMAIL", "given_name", "family_name", "email", "email_verified", "true"
 	)
 
 	createUserRequest := &cognitoidentityprovider.AdminCreateUserInput{
@@ -190,9 +189,11 @@ func (p UserParams) BuildCreateUserRequest(userId string, userPoolId string) *co
 		UserPoolId:        &userPoolId,
 		Username:          &userId,
 	}
+
 	if len(messageAction) > 0 {
 		createUserRequest.MessageAction = &messageAction
 	}
+
 	return createUserRequest
 }
 

--- a/models/users_test.go
+++ b/models/users_test.go
@@ -386,14 +386,32 @@ func TestUserParams_BuildCreateUserRequest(t *testing.T) {
 		userId := uuid.NewString()
 		userPoolId := "euwest-99-aabbcc"
 
-		response := user.BuildCreateUserRequest(userId, userPoolId)
+		Convey("given message action is set to RESEND", func() {
+			messageAction := "RESEND"
 
-		So(reflect.TypeOf(*response), ShouldEqual, reflect.TypeOf(cognitoidentityprovider.AdminCreateUserInput{}))
-		So(*response.Username, ShouldEqual, userId)
-		So(*response.UserPoolId, ShouldEqual, userPoolId)
-		So(*response.UserAttributes[0].Value, ShouldEqual, user.Forename)
-		So(*response.UserAttributes[1].Value, ShouldEqual, user.Lastname)
-		So(*response.UserAttributes[2].Value, ShouldEqual, user.Email)
+			response := user.BuildCreateUserRequest(userId, userPoolId, messageAction)
+
+			So(reflect.TypeOf(*response), ShouldEqual, reflect.TypeOf(cognitoidentityprovider.AdminCreateUserInput{}))
+			So(*response.Username, ShouldEqual, userId)
+			So(*response.UserPoolId, ShouldEqual, userPoolId)
+			So(*response.UserAttributes[0].Value, ShouldEqual, user.Forename)
+			So(*response.UserAttributes[1].Value, ShouldEqual, user.Lastname)
+			So(*response.UserAttributes[2].Value, ShouldEqual, user.Email)
+			So(*response.MessageAction, ShouldEqual, messageAction)
+		})
+
+		Convey("given message action is not set (empty string)", func() {
+
+			response := user.BuildCreateUserRequest(userId, userPoolId, "")
+
+			So(reflect.TypeOf(*response), ShouldEqual, reflect.TypeOf(cognitoidentityprovider.AdminCreateUserInput{}))
+			So(*response.Username, ShouldEqual, userId)
+			So(*response.UserPoolId, ShouldEqual, userPoolId)
+			So(*response.UserAttributes[0].Value, ShouldEqual, user.Forename)
+			So(*response.UserAttributes[1].Value, ShouldEqual, user.Lastname)
+			So(*response.UserAttributes[2].Value, ShouldEqual, user.Email)
+			So(*response.MessageAction, ShouldBeNil)
+		})
 	})
 }
 

--- a/scripts/import_users/README.md
+++ b/scripts/import_users/README.md
@@ -22,3 +22,4 @@ No further dependencies other than following configuration.
 | S3_REGION                    | S3 region name
 | USER_POOL_ID                 | Cognito user pool id
 | MESSAGE_ACTION               | Set to RESEND for existing user, keep empty for new user or set to SUPPRESS if you do not want to send any emails out to users
+| PERMANENT_PASSWORD           | Set permanent password instead of temporary password - allows for password reset to take place

--- a/scripts/import_users/config/config.go
+++ b/scripts/import_users/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	S3Region             string `envconfig:"S3_REGION" required:"true"`
 	AWSCognitoUserPoolID string `envconfig:"USER_POOL_ID" required:"true"`
 	AWSProfile           string `envconfig:"AWS_PROFILE" required:"true"`
+	MessageAction        string `envconfig:"MESSAGE_ACTION"`
+	PermanentPassword    bool   `envconfig:"PERMANENT_PASSWORD"`
 }
 
 func (c Config) GetS3UsersFilePath() string {

--- a/scripts/import_users/users/restore_users.go
+++ b/scripts/import_users/users/restore_users.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const suppressEmails = "SUPPRESS"
+
 func ImportUsersFromS3(ctx context.Context, config *config.Config) error {
 	log.Info(ctx, fmt.Sprintf("started restoring users to cognito from s3 file: %v", config.GetS3UsersFilePath()))
 
@@ -38,7 +40,7 @@ func ImportUsersFromS3(ctx context.Context, config *config.Config) error {
 		}
 	}
 
-	count := 1
+	var count int
 	for {
 		line, err := reader.Read()
 		if err != nil {
@@ -46,14 +48,39 @@ func ImportUsersFromS3(ctx context.Context, config *config.Config) error {
 				break
 			}
 		}
-		createUser(ctx, client, line, count, config, colsMap)
 		count += 1
+
+		userInfo, err := createUser(ctx, client, line, count, config, colsMap)
+		if err != nil {
+			log.Error(ctx, fmt.Sprintf("failed to create user. Processline %v user: %v", count, userInfo), err)
+			continue
+		}
+
+		// Update password to be permanent if permanent passwrod env variable set to true,
+		// allows user to reset password
+		if config.PermanentPassword {
+			if err = makeUserPasswordPermanent(ctx, config, client, userInfo); err != nil {
+				log.Error(ctx, fmt.Sprintf("failed to make user password permanent. Processline %v user: %v", count, userInfo), err)
+				continue
+			}
+		}
+
+		// Disable user if it's 'enabled' column is not TRUE
+		enabledCol, ok := colsMap["enabled"]
+		if ok && len(line) > enabledCol && line[enabledCol] == "false" {
+			if err = disableUser(ctx, config, client, userInfo); err != nil {
+				log.Error(ctx, fmt.Sprintf("failed to disable user. Processline %v user: %v", count, userInfo), err)
+				continue
+			}
+		}
 	}
+
 	log.Info(ctx, "Successfully processed all the users in S3 file")
+
 	return nil
 }
 
-func createUser(ctx context.Context, client *cognitoidentityprovider.CognitoIdentityProvider, line []string, lineNumber int, config *config.Config, colsMap map[string]int) {
+func createUser(ctx context.Context, client *cognitoidentityprovider.CognitoIdentityProvider, line []string, lineNumber int, config *config.Config, colsMap map[string]int) (*models.UserParams, error) {
 	userInfo := models.UserParams{
 		Forename: line[colsMap["given_name"]],
 		Lastname: line[colsMap["family_name"]],
@@ -62,19 +89,31 @@ func createUser(ctx context.Context, client *cognitoidentityprovider.CognitoIden
 	}
 	userInfo.GeneratePassword(ctx)
 
-	createUserRequest := userInfo.BuildCreateUserRequest(userInfo.ID, config.AWSCognitoUserPoolID)
+	createUserRequest := userInfo.BuildCreateUserRequest(userInfo.ID, config.AWSCognitoUserPoolID, config.MessageAction)
 	_, err := client.AdminCreateUser(createUserRequest)
 	if err != nil {
-		log.Error(ctx, fmt.Sprintf("failed to processline %v user: %+v", lineNumber, userInfo), err)
+		return nil, err
 	}
 
-	//Disable user if it's 'enabled' column is not TRUE
-	enabledCol, ok := colsMap["enabled"]
-	if ok && len(line) > enabledCol && line[enabledCol] == "false" {
-		userDisableRequest := userInfo.BuildDisableUserRequest(config.AWSCognitoUserPoolID)
-		if _, err = client.AdminDisableUser(userDisableRequest); err != nil {
-			log.Error(ctx, fmt.Sprintf("failed to disable user: %+v", userInfo), err)
-		}
-	}
+	return &userInfo, nil
+}
 
+func makeUserPasswordPermanent(ctx context.Context, config *config.Config, client *cognitoidentityprovider.CognitoIdentityProvider, userInfo *models.UserParams) (err error) {
+	perm := true
+	user := &cognitoidentityprovider.AdminSetUserPasswordInput{
+		Password:   &userInfo.Password,
+		Permanent:  &perm,
+		UserPoolId: &config.AWSCognitoUserPoolID,
+		Username:   &userInfo.ID,
+	}
+	_, err = client.AdminSetUserPassword(user)
+
+	return
+}
+
+func disableUser(ctx context.Context, config *config.Config, client *cognitoidentityprovider.CognitoIdentityProvider, userInfo *models.UserParams) (err error) {
+	userDisableRequest := userInfo.BuildDisableUserRequest(config.AWSCognitoUserPoolID)
+	_, err = client.AdminDisableUser(userDisableRequest)
+
+	return
 }


### PR DESCRIPTION
### What

Additional flag to be used by the user import script to determine if we would likely users to be allowed to access account by asking for a new password, e.g. reset password functionality - currently this is not allowed while the user account is in state `FORCE_CHANGE_PASSWORD`; so update the state to `CONFIRMED` using password permanent feature in cognito.

Also refactored `MESSAGE_ACTION` env variable; this is only needed for script, so moved to script config instead of application config.

### How to review

- Check changes make sense
- Run script with new users and set environment variables `PERMANENT_PASSWORD` to `true` and `MESSAGE_ACTION` to `SUPPRESS`

### Who can review

Anyone
