### PR TITLE
fix to allow emails to have single quotes e.g. ...o'brien@... and more

### DIFF
--- a/scripts/utils/reset-password
+++ b/scripts/utils/reset-password
@@ -2,74 +2,83 @@
 
 set -eu
 
-usage(){
-        echo "reset-password -p pool_id [ -P profile ] [ email ]"
+usage() {
+        echo "Usage: reset-password [ -p pool_id ] [ -P aws_profile ] [ email ]"
+}
+die() {
+        local res=$1; shift
+        echo -e "\e[31m""ERROR:\e[0m $*" >&2
+        exit $res
 }
 
-profile=dp-prod
+export AWS_PROFILE=${AWS_PROFILE:-dp-prod}
 
 while [[ ${1-} == -* ]]; do
-    case $1 in
-            (-h) usage; exit; ;;
-            (-p) userPool=$2; shift; ;;
-            (-P) profile=$2; shift; ;;
-    esac
-    shift
+        case $1 in
+            (-h)    usage;          exit;  ;;
+            (-p)    userPool=$2;    shift; ;;
+            (-P)    AWS_PROFILE=$2; shift; ;;
+        esac
+        shift
 done
 
-if   [[ -z ${userPool-} ]]; then
-        echo "Need args: -p user_pool" >&2
-        usage
-        exit 2
+if [[ -z ${userPool-} ]]; then
+        identity_api_secrets=${DP_REPO_DIR-${ONS_DP_SRC_ROOT-does-not-exist}}/dp-configs/secrets/${AWS_PROFILE#dp-}/dp-identity-api.json
+        if [[ ! -f $identity_api_secrets ]]; then
+                usage >&2
+                die 2 "Need args: -p user_pool  (tried to obtain from \$DP_REPO_DIR/dp-configs/secrets/${AWS_PROFILE#dp-}/dp-identity-api.json)"
+        fi
+        userPool=$(jq -r .AWS_COGNITO_USER_POOL_ID $identity_api_secrets)
+        if [[ -z ${userPool-} || $userPool == null ]]; then
+                die 2 "Need args: -p user_pool  (failed to obtain from $identity_api_secrets)"
+        fi
 fi
 
 while [[ -z ${email-} ]]; do
-    if [[ -n ${1-} ]]; then
-        email=$1
-        shift
-    else
-        read -p "Email: " email
-    fi
+        if [[ -n ${1-} ]]; then
+                email=$1
+                shift
+        else
+                read -p "Email: " email
+        fi
 done
 
-json=$(aws cognito-idp list-users --user-pool-id $userPool --profile $profile --filter "email = '$email'")
+echo "Obtaining details in $AWS_PROFILE for email $email ..."
+json=$(aws cognito-idp list-users --user-pool-id $userPool --filter "email = \"$email\"")
 
 count_users=$(jq -r '.Users | length' <<<"$json")
 if [[ $count_users -ne 1 ]]; then
         jq . <<<"$json"
-        echo "Bad number of users - expected one" >&2
-        exit 2
+        die 2 "Bad number of users ($count_users) - expected one"
 fi
-echo "Got one user for $email"
+echo "In $AWS_PROFILE - Found expected user for $email"
 
 user_status=$(jq -r '.Users[0].UserStatus' <<<"$json")
 if   [[ $user_status == "CONFIRMED" ]]; then
         jq . <<<"$json"
-        echo "User already $user_status - please tell them:  This user is confirmed, get them to ask for a password reset" >&2
-        exit 2
+        die 2 "User already has status '$user_status' - please tell them:  This user is confirmed, get them to ask for a password reset" >&2
 elif [[ $user_status != "FORCE_CHANGE_PASSWORD" ]]; then
         jq . <<<"$json"
-        echo "User has status $user_status - not recognised" >&2
-        exit 2
+        die 2 "User has status '$user_status' - this status is not recognised"
 fi
-echo "Got status $user_status for $email"
+echo "In $AWS_PROFILE - Got expected status '$user_status' for $email"
 
 uuid=$(jq -r '.Users[0].Username' <<<"$json")
-if   [[ -z $uuid ]]; then
+if   [[ -z $uuid || $uuid == null ]]; then
         jq . <<<"$json"
-        echo "Cannot obtain UUID (Username) for $email" >&2
-        exit 2
+        die 2 "Cannot obtain UUID (Username) for $email"
 fi
-echo "Got uuid $uuid for $email"
+echo "In $AWS_PROFILE - Got uuid (really Username) '$uuid' for $email"
 
-json_2=$(aws cognito-idp admin-get-user --profile $profile --user-pool-id ${userPool} --username="${uuid}")
-
-email_check=$(jq -r '.Email' <<<"$json_2")
-if [[ $email_check == $email ]]; then
-        jq . <<<"$json_2"
-        echo "Count not see email in check" >&2
-        exit 2
+# double check uuid obtains same email
+json_check=$(aws cognito-idp admin-get-user --user-pool-id ${userPool} --username="${uuid}")
+email_check=$(jq -r '.UserAttributes[] | select(.Name=="email") | .Value' <<<"$json_check")
+if [[ $email_check != $email ]]; then
+        jq . <<<"$json_check"
+        die 2 "Could not match email ($email) during check - got email: $email_check"
 fi
 
-echo Resetting password for $email ...
-aws cognito-idp admin-set-user-password --profile $profile --user-pool-id ${userPool} --username="${uuid}" --password "#1Ab$(openssl rand -base64 12)" --permanent
+echo "In $AWS_PROFILE - Resetting password for $email ..."
+aws cognito-idp admin-set-user-password --user-pool-id ${userPool} --username="${uuid}" --password "#1Ab$(openssl rand -base64 12)" --permanent
+echo -e "\e[32m""Success.\e[0m Please report back:"
+echo -e "  \e[36m""We've reset the password for $email - they should be able to click 'Forgotten Password' in ${AWS_PROFILE#dp-} Florence, to get an email to set a new password. Thank you.\e[0m"


### PR DESCRIPTION
- fix to allow emails to have single quotes e.g. `...o'brien@...`
- bug fix to check email at end (wasn't working)
- make `-p` optional - obtain Cognito UserPool ID from secrets
