### PR TITLE
Implement sort users by forename asc and desc

### DIFF
--- a/api/groups.go
+++ b/api/groups.go
@@ -6,12 +6,14 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"github.com/ONSdigital/dp-identity-api/models"
+	dplogs "github.com/ONSdigital/log.go/v2/log"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -185,11 +187,44 @@ func (api *API) ListUsersInGroupHandler(ctx context.Context, w http.ResponseWrit
 	listOfUsers := models.UsersList{}
 	listOfUsers.MapCognitoUsers(&listUsers)
 
+	if err = req.ParseForm(); err != nil {
+		dplogs.Error(ctx, "error parsing form", err)
+	}
+	users := listOfUsers.Users
+	sortBy := strings.Split(req.Form.Get("sortBy"), ":")
+	sortUsers(ctx, users, sortBy)
+
 	jsonResponse, responseErr := listOfUsers.BuildSuccessfulJsonResponse(ctx)
 	if responseErr != nil {
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
+}
+
+func sortUsers(ctx context.Context, users []models.UserParams, sortBy []string) bool {
+	switch sortBy[0] {
+	case "forename":
+		switch sortBy[1] {
+		case "asc":
+			sortByUserNameAsc := func(i, j int) bool {
+				return users[i].Forename < users[j].Forename
+			}
+			sort.Slice(users, sortByUserNameAsc)
+			return true
+		case "desc":
+			sortByUserNameDesc := func(i, j int) bool {
+				return users[i].Forename > users[j].Forename
+			}
+			sort.Slice(users, sortByUserNameDesc)
+			return true
+		default:
+			dplogs.Info(ctx, "groups.sortUsers: Not a correct sort by value. Users not sorted.", dplogs.Data{"sortBy": sortBy})
+			return false
+		}
+	default:
+		dplogs.Info(ctx, "groups.sortUsers: Not a correct sort by value. Users not sorted.", dplogs.Data{"sortBy": sortBy})
+		return false
+	}
 }
 
 func (api *API) getUsersInAGroup(listOfUsers []*cognitoidentityprovider.UserType, group models.Group) ([]*cognitoidentityprovider.UserType, error) {

--- a/api/groups.go
+++ b/api/groups.go
@@ -192,7 +192,7 @@ func (api *API) ListUsersInGroupHandler(ctx context.Context, w http.ResponseWrit
 		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, err)
 	}
 	users := listOfUsers.Users
-	sortBy := strings.Split(req.Form.Get("sortBy"), ":")
+	sortBy := strings.Split(req.Form.Get("sort"), ":")
 	sortUsers(ctx, users, sortBy)
 
 	jsonResponse, responseErr := listOfUsers.BuildSuccessfulJsonResponse(ctx)
@@ -203,6 +203,9 @@ func (api *API) ListUsersInGroupHandler(ctx context.Context, w http.ResponseWrit
 }
 
 func sortUsers(ctx context.Context, users []models.UserParams, sortBy []string) bool {
+	if sortBy[0] == "created" || sortBy[0] == "" {
+		return true
+	}
 	switch sortBy[0] {
 	case "forename":
 		switch sortBy[1] {

--- a/api/groups.go
+++ b/api/groups.go
@@ -189,6 +189,7 @@ func (api *API) ListUsersInGroupHandler(ctx context.Context, w http.ResponseWrit
 
 	if err = req.ParseForm(); err != nil {
 		dplogs.Error(ctx, "error parsing form", err)
+		return nil, models.NewErrorResponse(http.StatusBadRequest, nil, err)
 	}
 	users := listOfUsers.Users
 	sortBy := strings.Split(req.Form.Get("sortBy"), ":")

--- a/api/groups_test.go
+++ b/api/groups_test.go
@@ -2814,7 +2814,7 @@ func TestSortUsers(t *testing.T) {
 		json.Unmarshal([]byte(usersJson), &listOfUsers)
 		fmt.Println(listOfUsers.Users)
 
-		Convey("When we call the sort function with sortedBy value of forename:asc", func() {
+		Convey("When we call the sort function with sort value of forename:asc", func() {
 			users := listOfUsers.Users
 			sortBy := strings.Split("forename:asc", ":")
 			sorted := sortUsers(ctx, users, sortBy)
@@ -2831,7 +2831,7 @@ func TestSortUsers(t *testing.T) {
 			})
 		})
 
-		Convey("When we call the sort function with sortedBy value of forename:desc", func() {
+		Convey("When we call the sort function with sort value of forename:desc", func() {
 			users := listOfUsers.Users
 			sortBy := strings.Split("forename:desc", ":")
 			sorted := sortUsers(ctx, users, sortBy)
@@ -2845,7 +2845,7 @@ func TestSortUsers(t *testing.T) {
 			})
 		})
 
-		Convey("When we call the sort function with sortedBy value of wrongValue:desc", func() {
+		Convey("When we call the sort function with sort value of wrongValue:desc", func() {
 			users := listOfUsers.Users
 			sortBy := strings.Split("wrongValue:desc", ":")
 			sorted := sortUsers(ctx, users, sortBy)
@@ -2859,7 +2859,7 @@ func TestSortUsers(t *testing.T) {
 			})
 		})
 
-		Convey("When we call the sort function with sortedBy value of forename:wrongValue", func() {
+		Convey("When we call the sort function with sort value of forename:wrongValue", func() {
 			users := listOfUsers.Users
 			sortBy := strings.Split("forename:wrongValue", ":")
 			sorted := sortUsers(ctx, users, sortBy)
@@ -2869,6 +2869,34 @@ func TestSortUsers(t *testing.T) {
 				json.Unmarshal([]byte(usersJson), &listOfUsersUnsorted)
 
 				So(sorted, ShouldBeFalse)
+				So(users, ShouldResemble, listOfUsersUnsorted.Users)
+			})
+		})
+
+		Convey("When we call the sort function with sort value of created", func() {
+			users := listOfUsers.Users
+			sortBy := strings.Split("created", ":")
+			sorted := sortUsers(ctx, users, sortBy)
+
+			Convey("Then the users should be returned in the order they where created", func() {
+				listOfUsersUnsorted := models.UsersList{}
+				json.Unmarshal([]byte(usersJson), &listOfUsersUnsorted)
+
+				So(sorted, ShouldBeTrue)
+				So(users, ShouldResemble, listOfUsersUnsorted.Users)
+			})
+		})
+
+		Convey("When we call the sort function with sort value of \"\"", func() {
+			users := listOfUsers.Users
+			sortBy := strings.Split("", ":")
+			sorted := sortUsers(ctx, users, sortBy)
+
+			Convey("Then the users should be returned in the order they where created", func() {
+				listOfUsersUnsorted := models.UsersList{}
+				json.Unmarshal([]byte(usersJson), &listOfUsersUnsorted)
+
+				So(sorted, ShouldBeTrue)
 				So(users, ShouldResemble, listOfUsersUnsorted.Users)
 			})
 		})

--- a/api/groups_test.go
+++ b/api/groups_test.go
@@ -29,6 +29,113 @@ const (
 	createGroupEndPoint         = "http://localhost:25600/v1/groups"
 	getListGroupsEndPoint       = "http://localhost:25600/v1/groups"
 	updateGroupEndPoint         = "http://localhost:25600/v1/groups/123e4567-e89b-12d3-a456-426614174000"
+	usersJson                   = `{
+  "count": 3,
+  "users": [
+    {
+      "forename": "DTestForename",
+      "lastname": "LTestSurname",
+      "email": "DTestForename.LTestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    },
+    {
+      "forename": "ATestForename",
+      "lastname": "HTestSurname",
+      "email": "ATestForename.HTestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    },
+    {
+      "forename": "OTestForename",
+      "lastname": "STestSurname",
+      "email": "OTestForename.STestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    } ],
+  "PaginationToken": ""
+}`
+	usersSortedByForenameAsc = `{
+  "count": 3,
+  "users": [
+    {
+      "forename": "ATestForename",
+      "lastname": "HTestSurname",
+      "email": "ATestForename.HTestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    },
+    {
+      "forename": "DTestForename",
+      "lastname": "LTestSurname",
+      "email": "DTestForename.LTestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    },
+    {
+      "forename": "OTestForename",
+      "lastname": "STestSurname",
+      "email": "OTestForename.STestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    }
+  ],
+  "PaginationToken": ""
+}`
+	usersSortedByForenameDesc = `{
+  "count": 3,
+  "users": [
+    {
+      "forename": "OTestForename",
+      "lastname": "STestSurname",
+      "email": "OTestForename.STestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    },
+    {
+      "forename": "DTestForename",
+      "lastname": "LTestSurname",
+      "email": "DTestForename.LTestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    },
+    {
+      "forename": "ATestForename",
+      "lastname": "HTestSurname",
+      "email": "ATestForename.HTestSurname@ons.gov.uk",
+      "groups": [],
+      "status": "CONFIRMED",
+      "active": true,
+      "id": "1234",
+      "status_notes": ""
+    }
+  ],
+  "PaginationToken": ""
+}`
 )
 
 var (
@@ -2703,9 +2810,8 @@ func TestListGroupsUsersHandler(t *testing.T) {
 
 func TestSortUsers(t *testing.T) {
 	Convey("Given we have some test users", t, func() {
-		json1 := "{\n  \"count\": 9,\n  \"users\": [\n    {\n      \"forename\": \"DTestForename\",\n      \"lastname\": \"LTestSurname\",\n      \"email\": \"DTestForename.LTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"ATestForename\",\n      \"lastname\": \"HTestSurname\",\n      \"email\": \"ATestForename.HTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"OTestForename\",\n      \"lastname\": \"STestSurname\",\n      \"email\": \"OTestForename.STestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    } ],\n  \"PaginationToken\": \"\"\n}"
 		listOfUsers := models.UsersList{}
-		json.Unmarshal([]byte(json1), &listOfUsers)
+		json.Unmarshal([]byte(usersJson), &listOfUsers)
 		fmt.Println(listOfUsers.Users)
 
 		Convey("When we call the sort function with sortedBy value of forename:asc", func() {
@@ -2717,7 +2823,6 @@ func TestSortUsers(t *testing.T) {
 			fmt.Printf("jsonTmp = %s\n", string(jsonTmp))
 
 			Convey("Then the users should be sorted by forename in ascending order", func() {
-				usersSortedByForenameAsc := "{\n  \"count\": 9,\n  \"users\": [\n    {\"forename\":\"ATestForename\",\"lastname\":\"HTestSurname\",\"email\":\"ATestForename.HTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"DTestForename\",\"lastname\":\"LTestSurname\",\"email\":\"DTestForename.LTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"OTestForename\",\"lastname\":\"STestSurname\",\"email\":\"OTestForename.STestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"} ],\n  \"PaginationToken\": \"\"\n}"
 				listOfUsersSortedByForenameAsc := models.UsersList{}
 				json.Unmarshal([]byte(usersSortedByForenameAsc), &listOfUsersSortedByForenameAsc)
 
@@ -2732,7 +2837,6 @@ func TestSortUsers(t *testing.T) {
 			sorted := sortUsers(ctx, users, sortBy)
 
 			Convey("Then the users should be sorted by forename in descending order", func() {
-				usersSortedByForenameDesc := "{\n  \"count\": 9,\n  \"users\": [\n    {\"forename\":\"OTestForename\",\"lastname\":\"STestSurname\",\"email\":\"OTestForename.STestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"DTestForename\",\"lastname\":\"LTestSurname\",\"email\":\"DTestForename.LTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"ATestForename\",\"lastname\":\"HTestSurname\",\"email\":\"ATestForename.HTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"} ],\n  \"PaginationToken\": \"\"\n}"
 				listOfUsersSortedByForenameDesc := models.UsersList{}
 				json.Unmarshal([]byte(usersSortedByForenameDesc), &listOfUsersSortedByForenameDesc)
 
@@ -2747,9 +2851,8 @@ func TestSortUsers(t *testing.T) {
 			sorted := sortUsers(ctx, users, sortBy)
 
 			Convey("Then the users should not be sorted", func() {
-				usersUnsorted := "{\n  \"count\": 9,\n  \"users\": [\n    {\n      \"forename\": \"DTestForename\",\n      \"lastname\": \"LTestSurname\",\n      \"email\": \"DTestForename.LTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"ATestForename\",\n      \"lastname\": \"HTestSurname\",\n      \"email\": \"ATestForename.HTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"OTestForename\",\n      \"lastname\": \"STestSurname\",\n      \"email\": \"OTestForename.STestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    } ],\n  \"PaginationToken\": \"\"\n}"
 				listOfUsersUnsorted := models.UsersList{}
-				json.Unmarshal([]byte(usersUnsorted), &listOfUsersUnsorted)
+				json.Unmarshal([]byte(usersJson), &listOfUsersUnsorted)
 
 				So(sorted, ShouldBeFalse)
 				So(users, ShouldResemble, listOfUsersUnsorted.Users)
@@ -2762,9 +2865,8 @@ func TestSortUsers(t *testing.T) {
 			sorted := sortUsers(ctx, users, sortBy)
 
 			Convey("Then the users should not be sorted", func() {
-				usersUnsorted := "{\n  \"count\": 9,\n  \"users\": [\n    {\n      \"forename\": \"DTestForename\",\n      \"lastname\": \"LTestSurname\",\n      \"email\": \"DTestForename.LTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"ATestForename\",\n      \"lastname\": \"HTestSurname\",\n      \"email\": \"ATestForename.HTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"OTestForename\",\n      \"lastname\": \"STestSurname\",\n      \"email\": \"OTestForename.STestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    } ],\n  \"PaginationToken\": \"\"\n}"
 				listOfUsersUnsorted := models.UsersList{}
-				json.Unmarshal([]byte(usersUnsorted), &listOfUsersUnsorted)
+				json.Unmarshal([]byte(usersJson), &listOfUsersUnsorted)
 
 				So(sorted, ShouldBeFalse)
 				So(users, ShouldResemble, listOfUsersUnsorted.Users)

--- a/api/groups_test.go
+++ b/api/groups_test.go
@@ -2701,6 +2701,78 @@ func TestListGroupsUsersHandler(t *testing.T) {
 	})
 }
 
+func TestSortUsers(t *testing.T) {
+	Convey("Given we have some test users", t, func() {
+		json1 := "{\n  \"count\": 9,\n  \"users\": [\n    {\n      \"forename\": \"DTestForename\",\n      \"lastname\": \"LTestSurname\",\n      \"email\": \"DTestForename.LTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"ATestForename\",\n      \"lastname\": \"HTestSurname\",\n      \"email\": \"ATestForename.HTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"OTestForename\",\n      \"lastname\": \"STestSurname\",\n      \"email\": \"OTestForename.STestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    } ],\n  \"PaginationToken\": \"\"\n}"
+		listOfUsers := models.UsersList{}
+		json.Unmarshal([]byte(json1), &listOfUsers)
+		fmt.Println(listOfUsers.Users)
+
+		Convey("When we call the sort function with sortedBy value of forename:asc", func() {
+			users := listOfUsers.Users
+			sortBy := strings.Split("forename:asc", ":")
+			sorted := sortUsers(ctx, users, sortBy)
+
+			jsonTmp, _ := json.Marshal(users)
+			fmt.Printf("jsonTmp = %s\n", string(jsonTmp))
+
+			Convey("Then the users should be sorted by forename in ascending order", func() {
+				usersSortedByForenameAsc := "{\n  \"count\": 9,\n  \"users\": [\n    {\"forename\":\"ATestForename\",\"lastname\":\"HTestSurname\",\"email\":\"ATestForename.HTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"DTestForename\",\"lastname\":\"LTestSurname\",\"email\":\"DTestForename.LTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"OTestForename\",\"lastname\":\"STestSurname\",\"email\":\"OTestForename.STestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"} ],\n  \"PaginationToken\": \"\"\n}"
+				listOfUsersSortedByForenameAsc := models.UsersList{}
+				json.Unmarshal([]byte(usersSortedByForenameAsc), &listOfUsersSortedByForenameAsc)
+
+				So(sorted, ShouldBeTrue)
+				So(users, ShouldResemble, listOfUsersSortedByForenameAsc.Users)
+			})
+		})
+
+		Convey("When we call the sort function with sortedBy value of forename:desc", func() {
+			users := listOfUsers.Users
+			sortBy := strings.Split("forename:desc", ":")
+			sorted := sortUsers(ctx, users, sortBy)
+
+			Convey("Then the users should be sorted by forename in descending order", func() {
+				usersSortedByForenameDesc := "{\n  \"count\": 9,\n  \"users\": [\n    {\"forename\":\"OTestForename\",\"lastname\":\"STestSurname\",\"email\":\"OTestForename.STestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"DTestForename\",\"lastname\":\"LTestSurname\",\"email\":\"DTestForename.LTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"},{\"forename\":\"ATestForename\",\"lastname\":\"HTestSurname\",\"email\":\"ATestForename.HTestSurname@ons.gov.uk\",\"groups\":[],\"status\":\"CONFIRMED\",\"active\":true,\"id\":\"1234\",\"status_notes\":\"\"} ],\n  \"PaginationToken\": \"\"\n}"
+				listOfUsersSortedByForenameDesc := models.UsersList{}
+				json.Unmarshal([]byte(usersSortedByForenameDesc), &listOfUsersSortedByForenameDesc)
+
+				So(sorted, ShouldBeTrue)
+				So(users, ShouldResemble, listOfUsersSortedByForenameDesc.Users)
+			})
+		})
+
+		Convey("When we call the sort function with sortedBy value of wrongValue:desc", func() {
+			users := listOfUsers.Users
+			sortBy := strings.Split("wrongValue:desc", ":")
+			sorted := sortUsers(ctx, users, sortBy)
+
+			Convey("Then the users should not be sorted", func() {
+				usersUnsorted := "{\n  \"count\": 9,\n  \"users\": [\n    {\n      \"forename\": \"DTestForename\",\n      \"lastname\": \"LTestSurname\",\n      \"email\": \"DTestForename.LTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"ATestForename\",\n      \"lastname\": \"HTestSurname\",\n      \"email\": \"ATestForename.HTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"OTestForename\",\n      \"lastname\": \"STestSurname\",\n      \"email\": \"OTestForename.STestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    } ],\n  \"PaginationToken\": \"\"\n}"
+				listOfUsersUnsorted := models.UsersList{}
+				json.Unmarshal([]byte(usersUnsorted), &listOfUsersUnsorted)
+
+				So(sorted, ShouldBeFalse)
+				So(users, ShouldResemble, listOfUsersUnsorted.Users)
+			})
+		})
+
+		Convey("When we call the sort function with sortedBy value of forename:wrongValue", func() {
+			users := listOfUsers.Users
+			sortBy := strings.Split("forename:wrongValue", ":")
+			sorted := sortUsers(ctx, users, sortBy)
+
+			Convey("Then the users should not be sorted", func() {
+				usersUnsorted := "{\n  \"count\": 9,\n  \"users\": [\n    {\n      \"forename\": \"DTestForename\",\n      \"lastname\": \"LTestSurname\",\n      \"email\": \"DTestForename.LTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"ATestForename\",\n      \"lastname\": \"HTestSurname\",\n      \"email\": \"ATestForename.HTestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    },\n    {\n      \"forename\": \"OTestForename\",\n      \"lastname\": \"STestSurname\",\n      \"email\": \"OTestForename.STestSurname@ons.gov.uk\",\n      \"groups\": [],\n      \"status\": \"CONFIRMED\",\n      \"active\": true,\n      \"id\": \"1234\",\n      \"status_notes\": \"\"\n    } ],\n  \"PaginationToken\": \"\"\n}"
+				listOfUsersUnsorted := models.UsersList{}
+				json.Unmarshal([]byte(usersUnsorted), &listOfUsersUnsorted)
+
+				So(sorted, ShouldBeFalse)
+				So(users, ShouldResemble, listOfUsersUnsorted.Users)
+			})
+		})
+	})
+}
+
 // isCSV will test that there is more than one slice and a header row
 func isCSV(successResponse *models.SuccessResponse, expectedLength int) bool {
 	testOutCSV := string(successResponse.Body[:])

--- a/cognito/mock/user_mocker.go
+++ b/cognito/mock/user_mocker.go
@@ -27,14 +27,18 @@ func (m *CognitoIdentityProviderClientStub) AddUserWithUsername(username, email 
 	m.Users = append(m.Users, m.GenerateUser(username, email, "", "", "", isConfirmed))
 }
 
-//Generates the required number of users in the system
+func (m *CognitoIdentityProviderClientStub) AddUserWithForename(username, email, forename string, isConfirmed bool) {
+	m.Users = append(m.Users, m.GenerateUser(username, email, "", forename, "", isConfirmed))
+}
+
+// Generates the required number of users in the system
 func (m *CognitoIdentityProviderClientStub) AddMultipleUsers(usersCount int) {
 	for len(m.Users) < usersCount {
 		m.Users = append(m.Users, m.GenerateUser("", "", "", "", "", true))
 	}
 }
 
-//Generates the required number of users in the system
+// Generates the required number of users in the system
 func (m *CognitoIdentityProviderClientStub) AddMultipleActiveUsers(activeusersCount, inactiveusersCount int) {
 	for len(m.Users) < activeusersCount {
 		m.Users = append(m.Users, m.GenerateUser("", "", "", "", "", true))
@@ -107,8 +111,9 @@ func (m *CognitoIdentityProviderClientStub) MakeUserMember(userName string) {
 	}
 }
 
-//BulkGenerateUsers - bulk generate 'n' users for testing purposes
-//                    if usernames array is nil or length is different, will auto-assign UUIDs
+// BulkGenerateUsers - bulk generate 'n' users for testing purposes
+//
+//	if usernames array is nil or length is different, will auto-assign UUIDs
 func BulkGenerateUsers(userCount int, userNames []string) *cognitoidentityprovider.ListUsersOutput {
 	paginationToken := "abc-123-xyz-345-xxx"
 	usersList := &cognitoidentityprovider.ListUsersOutput{}

--- a/features/groups.feature
+++ b/features/groups.feature
@@ -579,6 +579,108 @@ Feature: Groups
                 }
             """
 
+    Scenario: GET /v1/groups/{id}/members?sortBy=forename:asc and checking the response status 200
+        Given group "test-group" exists in the database
+        And a user with username "abcd1234" and email "email@ons.gov.uk" and forename "Andreas" exists in the database
+        And a user with username "bcde1234" and email "email@ons.gov.uk" and forename "Dimitris" exists in the database
+        And a user with username "cdef1234" and email "email@ons.gov.uk" and forename "Zeus" exists in the database
+        And user "abcd1234" is a member of group "test-group"
+        And user "bcde1234" is a member of group "test-group"
+        And user "cdef1234" is a member of group "test-group"
+        And there are 3 users in group "test-group"
+        And I am an admin user
+        When I GET "/v1/groups/test-group/members?sortBy=forename:asc"
+        Then I should receive the following JSON response with status "200":
+            """
+                {
+                    "users": [
+                        {
+                            "id": "abcd1234",
+                            "forename": "Andreas",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "bcde1234",
+                            "forename": "Dimitris",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "cdef1234",
+                            "forename": "Zeus",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        }
+                    ],
+                    "count": 3,
+                    "PaginationToken":""
+                }
+            """
+
+    Scenario: GET /v1/groups/{id}/members?sortBy=forename:desc and checking the response status 200
+        Given group "test-group" exists in the database
+        And a user with username "abcd1234" and email "email@ons.gov.uk" and forename "Andreas" exists in the database
+        And a user with username "bcde1234" and email "email@ons.gov.uk" and forename "Dimitris" exists in the database
+        And a user with username "cdef1234" and email "email@ons.gov.uk" and forename "Zeus" exists in the database
+        And user "abcd1234" is a member of group "test-group"
+        And user "bcde1234" is a member of group "test-group"
+        And user "cdef1234" is a member of group "test-group"
+        And there are 3 users in group "test-group"
+        And I am an admin user
+        When I GET "/v1/groups/test-group/members?sortBy=forename:desc"
+        Then I should receive the following JSON response with status "200":
+            """
+                {
+                    "users": [
+                        {
+                            "id": "cdef1234",
+                            "forename": "Zeus",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "bcde1234",
+                            "forename": "Dimitris",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "abcd1234",
+                            "forename": "Andreas",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        }
+                    ],
+                    "count": 3,
+                    "PaginationToken":""
+                }
+            """
+
     Scenario: GET /v1/groups/{id}/members without a JWT token and checking the response status 401
         When I GET "/v1/groups/test-group/members"
         Then the HTTP status code should be "401"

--- a/features/groups.feature
+++ b/features/groups.feature
@@ -579,7 +579,7 @@ Feature: Groups
                 }
             """
 
-    Scenario: GET /v1/groups/{id}/members?sortBy=forename:asc and checking the response status 200
+    Scenario: GET /v1/groups/{id}/members?sort=forename:asc and checking the response status 200
         Given group "test-group" exists in the database
         And a user with username "abcd1234" and email "email@ons.gov.uk" and forename "Andreas" exists in the database
         And a user with username "bcde1234" and email "email@ons.gov.uk" and forename "Dimitris" exists in the database
@@ -589,7 +589,7 @@ Feature: Groups
         And user "cdef1234" is a member of group "test-group"
         And there are 3 users in group "test-group"
         And I am an admin user
-        When I GET "/v1/groups/test-group/members?sortBy=forename:asc"
+        When I GET "/v1/groups/test-group/members?sort=forename:asc"
         Then I should receive the following JSON response with status "200":
             """
                 {
@@ -630,7 +630,7 @@ Feature: Groups
                 }
             """
 
-    Scenario: GET /v1/groups/{id}/members?sortBy=forename:desc and checking the response status 200
+    Scenario: GET /v1/groups/{id}/members?sort=forename:desc and checking the response status 200
         Given group "test-group" exists in the database
         And a user with username "abcd1234" and email "email@ons.gov.uk" and forename "Andreas" exists in the database
         And a user with username "bcde1234" and email "email@ons.gov.uk" and forename "Dimitris" exists in the database
@@ -640,7 +640,7 @@ Feature: Groups
         And user "cdef1234" is a member of group "test-group"
         And there are 3 users in group "test-group"
         And I am an admin user
-        When I GET "/v1/groups/test-group/members?sortBy=forename:desc"
+        When I GET "/v1/groups/test-group/members?sort=forename:desc"
         Then I should receive the following JSON response with status "200":
             """
                 {
@@ -668,6 +668,108 @@ Feature: Groups
                         {
                             "id": "abcd1234",
                             "forename": "Andreas",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        }
+                    ],
+                    "count": 3,
+                    "PaginationToken":""
+                }
+            """
+
+    Scenario: GET /v1/groups/{id}/members?sort=created and checking the response status 200
+        Given group "test-group" exists in the database
+        And a user with username "abcd1234" and email "email@ons.gov.uk" and forename "Andreas" exists in the database
+        And a user with username "bcde1234" and email "email@ons.gov.uk" and forename "Dimitris" exists in the database
+        And a user with username "cdef1234" and email "email@ons.gov.uk" and forename "Zeus" exists in the database
+        And user "abcd1234" is a member of group "test-group"
+        And user "bcde1234" is a member of group "test-group"
+        And user "cdef1234" is a member of group "test-group"
+        And there are 3 users in group "test-group"
+        And I am an admin user
+        When I GET "/v1/groups/test-group/members?sort=created"
+        Then I should receive the following JSON response with status "200":
+            """
+                {
+                    "users": [
+                        {
+                            "id": "abcd1234",
+                            "forename": "Andreas",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "bcde1234",
+                            "forename": "Dimitris",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "cdef1234",
+                            "forename": "Zeus",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        }
+                    ],
+                    "count": 3,
+                    "PaginationToken":""
+                }
+            """
+
+    Scenario: GET /v1/groups/{id}/members and checking the response status 200
+        Given group "test-group" exists in the database
+        And a user with username "abcd1234" and email "email@ons.gov.uk" and forename "Andreas" exists in the database
+        And a user with username "bcde1234" and email "email@ons.gov.uk" and forename "Dimitris" exists in the database
+        And a user with username "cdef1234" and email "email@ons.gov.uk" and forename "Zeus" exists in the database
+        And user "abcd1234" is a member of group "test-group"
+        And user "bcde1234" is a member of group "test-group"
+        And user "cdef1234" is a member of group "test-group"
+        And there are 3 users in group "test-group"
+        And I am an admin user
+        When I GET "/v1/groups/test-group/members"
+        Then I should receive the following JSON response with status "200":
+            """
+                {
+                    "users": [
+                        {
+                            "id": "abcd1234",
+                            "forename": "Andreas",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "bcde1234",
+                            "forename": "Dimitris",
+                            "lastname": "Smith",
+                            "email": "email@ons.gov.uk",
+                            "groups": [],
+                            "status": "CONFIRMED",
+                            "active": true,
+                            "status_notes": ""
+                        },
+                        {
+                            "id": "cdef1234",
+                            "forename": "Zeus",
                             "lastname": "Smith",
                             "email": "email@ons.gov.uk",
                             "groups": [],

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -28,6 +28,7 @@ func (c *IdentityComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^a user with email "([^"]*)" and password "([^"]*)" exists in the database$`, c.aUserWithEmailAndPasswordExistsInTheDatabase)
 	ctx.Step(`^a user with non-verified email "([^"]*)" and password "([^"]*)"$`, c.aUserWithNonverifiedEmailAndPassword)
 	ctx.Step(`^a user with username "([^"]*)" and email "([^"]*)" exists in the database$`, c.aUserWithUsernameAndEmailExistsInTheDatabase)
+	ctx.Step(`^a user with username "([^"]*)" and email "([^"]*)" and forename "([^"]*)" exists in the database$`, c.aUserWithUsernameAndEmailAndForenameExistsInTheDatabase)
 	ctx.Step(`^an error is returned from Cognito$`, c.anErrorIsReturnedFromCognito)
 	ctx.Step(`^an internal server error is returned from Cognito$`, c.anInternalServerErrorIsReturnedFromCognito)
 	ctx.Step(`^group "([^"]*)" and description "([^"]*)" exists in the database$`, c.groupAndDescriptionExistsInTheDatabase)
@@ -59,6 +60,11 @@ func (c *IdentityComponent) aUserWithEmailAndPasswordExistsInTheDatabase(email, 
 
 func (c *IdentityComponent) aUserWithUsernameAndEmailExistsInTheDatabase(username, email string) error {
 	c.CognitoClient.AddUserWithUsername(username, email, true)
+	return nil
+}
+
+func (c *IdentityComponent) aUserWithUsernameAndEmailAndForenameExistsInTheDatabase(username, email, forename string) error {
+	c.CognitoClient.AddUserWithForename(username, email, forename, true)
 	return nil
 }
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -696,8 +696,9 @@ paths:
           type: string
           required: false
           default: created
-          # for example, you can get the users in ascending order like this "http://localhost:25600/v1/groups/5/members?sort=forename:asc"
-          # and you can get the users in descending order like this "http://localhost:25600/v1/groups/5/members?sort=forename:desc"
+          enum:
+            - forename:asc
+            - forename:desc
       responses:
         200:
           description: "List of users in the group"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -703,6 +703,60 @@ paths:
           description: "Unexpected Cognito response"
           schema:
             $ref: '#/definitions/ErrorResponse'
+  /groups/{id}/members?sortBy=forename:asc:
+    get:
+      tags:
+        - Groups
+      summary: "Returns a list of users in a given group order by forename in ascending order"
+      description: "Returns a list of users in a given group in Cognito"
+      produces:
+        - "application/json"
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: the group's ID
+      responses:
+        200:
+          description: "List of users in the group"
+          schema:
+            $ref: '#/definitions/Group'
+        404:
+          description: "Invalid group ID provided"
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        500:
+          description: "Unexpected Cognito response"
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  /groups/{id}/members?sortBy=forename:desc:
+    get:
+      tags:
+        - Groups
+      summary: "Returns a list of users in a given group order by forename in descending order"
+      description: "Returns a list of users in a given group in Cognito"
+      produces:
+        - "application/json"
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: the group's ID
+      responses:
+        200:
+          description: "List of users in the group"
+          schema:
+            $ref: '#/definitions/Group'
+        404:
+          description: "Invalid group ID provided"
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        500:
+          description: "Unexpected Cognito response"
+          schema:
+            $ref: '#/definitions/ErrorResponse'
   /groups/{id}/members/{user_id}:
     delete:
       tags:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -696,6 +696,8 @@ paths:
           type: string
           required: false
           default: created
+          # for example, you can get the users in ascending order like this "http://localhost:25600/v1/groups/5/members?sort=forename:asc"
+          # and you can get the users in descending order like this "http://localhost:25600/v1/groups/5/members?sort=forename:desc"
       responses:
         200:
           description: "List of users in the group"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -690,60 +690,12 @@ paths:
           type: string
           required: true
           description: the group's ID
-      responses:
-        200:
-          description: "List of users in the group"
-          schema:
-            $ref: '#/definitions/Group'
-        404:
-          description: "Invalid group ID provided"
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        500:
-          description: "Unexpected Cognito response"
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-  /groups/{id}/members?sortBy=forename:asc:
-    get:
-      tags:
-        - Groups
-      summary: "Returns a list of users in a given group order by forename in ascending order"
-      description: "Returns a list of users in a given group in Cognito"
-      produces:
-        - "application/json"
-      parameters:
-        - in: path
-          name: id
+        - in: query
+          name: sort
+          description: The sort order of the returned set of users
           type: string
-          required: true
-          description: the group's ID
-      responses:
-        200:
-          description: "List of users in the group"
-          schema:
-            $ref: '#/definitions/Group'
-        404:
-          description: "Invalid group ID provided"
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        500:
-          description: "Unexpected Cognito response"
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-  /groups/{id}/members?sortBy=forename:desc:
-    get:
-      tags:
-        - Groups
-      summary: "Returns a list of users in a given group order by forename in descending order"
-      description: "Returns a list of users in a given group in Cognito"
-      produces:
-        - "application/json"
-      parameters:
-        - in: path
-          name: id
-          type: string
-          required: true
-          description: the group's ID
+          required: false
+          default: created
       responses:
         200:
           description: "List of users in the group"


### PR DESCRIPTION
### What

Add sort parameter to /groups/{id}/members endpoint

### How to review

Checkout this branch
Run the auth stack and navigate to http://localhost:25600/v1/groups/5/members?sortBy=forename:asc
You should see the users in ascending order
Navigate to http://localhost:25600/v1/groups/5/members?sortBy=forename:desc
You should see the users in descending order

### Who can review

Anyone
