### PR TITLE
Make env clearer, change flag, get user to check

### DIFF
--- a/scripts/utils/reset-password
+++ b/scripts/utils/reset-password
@@ -3,7 +3,7 @@
 set -eu
 
 usage() {
-        echo "Usage: reset-password [ -p pool_id ] [ -P aws_profile ] [ email ]"
+        echo "Usage: reset-password [ -p pool_id ] [ -e aws_profile ] [ email ]"
 }
 die() {
         local res=$1; shift
@@ -11,45 +11,57 @@ die() {
         exit $res
 }
 
-export AWS_PROFILE=${AWS_PROFILE:-dp-prod}
-
 while [[ ${1-} == -* ]]; do
         case $1 in
             (-h)    usage;          exit;  ;;
             (-p)    userPool=$2;    shift; ;;
-            (-P)    AWS_PROFILE=$2; shift; ;;
+            (-e)    AWS_PROFILE=$2; shift; ;;
+            (-*)    usage >&2; die 2 "No such flag '$1'"; ;;
+            (*)     if [[ $1 == *@* ]]; then
+                            email=$1
+                    else
+                            usage >&2
+                            die 2 "Expected email address, got: '$1'"
+                    fi
+                    ;;
         esac
         shift
 done
 
+export AWS_PROFILE=${AWS_PROFILE:-dp-prod}
+dp_env=${AWS_PROFILE#dp-}
+
+
 if [[ -z ${userPool-} ]]; then
-        identity_api_secrets=${DP_REPO_DIR-${ONS_DP_SRC_ROOT-does-not-exist}}/dp-configs/secrets/${AWS_PROFILE#dp-}/dp-identity-api.json
+        identity_api_secrets=${DP_REPO_DIR-${ONS_DP_SRC_ROOT-does-not-exist}}/dp-configs/secrets/$dp_env/dp-identity-api.json
         if [[ ! -f $identity_api_secrets ]]; then
                 usage >&2
-                die 2 "Need args: -p user_pool  (tried to obtain from \$DP_REPO_DIR/dp-configs/secrets/${AWS_PROFILE#dp-}/dp-identity-api.json)"
+                die 2 "Need args: -p user_pool  (tried to obtain from \$DP_REPO_DIR/dp-configs/secrets/$dp_env/dp-identity-api.json)"
         fi
+        echo "In $AWS_PROFILE - Obtaining Cognito User Pool ID from $identity_api_secrets"
         userPool=$(jq -r .AWS_COGNITO_USER_POOL_ID $identity_api_secrets)
         if [[ -z ${userPool-} || $userPool == null ]]; then
                 die 2 "Need args: -p user_pool  (failed to obtain from $identity_api_secrets)"
         fi
 fi
 
-while [[ -z ${email-} ]]; do
+while [[ -z ${email-} || ${email-} != *@* ]]; do
         if [[ -n ${1-} ]]; then
                 email=$1
                 shift
         else
-                read -p "Email: " email
+                echo -en "In \e[33m$AWS_PROFILE\e[0m - Email: "
+                read email
         fi
 done
 
-echo "Obtaining details in $AWS_PROFILE for email $email ..."
+echo "In $AWS_PROFILE - Obtaining details for email $email ..."
 json=$(aws cognito-idp list-users --user-pool-id $userPool --filter "email = \"$email\"")
 
 count_users=$(jq -r '.Users | length' <<<"$json")
 if [[ $count_users -ne 1 ]]; then
         jq . <<<"$json"
-        die 2 "Bad number of users ($count_users) - expected one"
+        die 2 "Bad number of users ($count_users) matched '$email' - expected one"
 fi
 echo "In $AWS_PROFILE - Found expected user for $email"
 
@@ -78,7 +90,8 @@ if [[ $email_check != $email ]]; then
         die 2 "Could not match email ($email) during check - got email: $email_check"
 fi
 
-echo "In $AWS_PROFILE - Resetting password for $email ..."
+echo -en "In \e[33m$AWS_PROFILE\e[0m - Reset password for \e[36m$email\e[0m \e[34m[Enter=continue]\e[0m "
+read yorn
 aws cognito-idp admin-set-user-password --user-pool-id ${userPool} --username="${uuid}" --password "#1Ab$(openssl rand -base64 12)" --permanent
 echo -e "\e[32m""Success.\e[0m Please report back:"
-echo -e "  \e[36m""We've reset the password for $email - they should be able to click 'Forgotten Password' in ${AWS_PROFILE#dp-} Florence, to get an email to set a new password. Thank you.\e[0m"
+echo -e "\e[36m""We've reset the account for $email in ${dp_env@u} - they should now be able to use 'Forgotten Password' in ${dp_env@u} Florence, to get an email to set a new password. Thank you.\e[0m"


### PR DESCRIPTION
- new flag for env `-e dp-prod` (better than `-P`)
- clearer to user which env
- allow user to bail if wrong env