### PR TITLE
Fix/fix refresh expiry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ build:
 	@mkdir -p $(BUILD_ARCH)/$(BIN_DIR)
 	go build $(LDFLAGS) -o $(BUILD_ARCH)/$(BIN_DIR)/$(MAIN) main.go
 
+.PHONY: debug-watch
+debug-watch: 
+	reflex -d none -c ./reflex
+
 .PHONY: debug
 debug:
 	export AWS_COGNITO_USER_POOL_ID=$(LOCAL_USER_POOL_ID);

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ An API used to manage the authorisation of users accessing data publishing servi
 
 ### Getting started
 
-* Run `make debug`
+Run `make debug` to get started
+
+To run the app with reflex and have it restart when you make changes, run:
+
+`make debug-watch`
 
 ### Dummy data
 If test data is required in the local Cognito user pool:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-dp-identity-api
-================
+# dp-identity-api
+
 An API used to manage the authorisation of users accessing data publishing services.
 
-### Getting started
+## Getting started
 
 Run `make debug` to get started
 
@@ -11,6 +11,7 @@ To run the app with reflex and have it restart when you make changes, run:
 `make debug-watch`
 
 ### Dummy data
+
 If test data is required in the local Cognito user pool:
 
 * Run `make populate-local`
@@ -45,7 +46,8 @@ To get the values for the other AWS Cognito secrets:
 * AWS_COGNITO_CLIENT_SECRET get from AWS > Cognito > User Pools > App Integration > App clients > dp-identity-api > client secret
 
 ### Configuration needed to import user and group from s3
-```
+
+```sh
 export GroupsFilename=""
 export GroupUsersFilename=""
 export UserFileName=""
@@ -55,12 +57,12 @@ export S3Region=""
 export AWSCognitoUserPoolID=""
 ```
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### License
+## License
 
-Copyright © 2021, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2024, [Office for National Statistics](https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.

--- a/api/tokens_test.go
+++ b/api/tokens_test.go
@@ -47,9 +47,14 @@ func TestAPI_TokensHandler(t *testing.T) {
 	}
 	m.DescribeUserPoolClientFunc = func(input *cognitoidentityprovider.DescribeUserPoolClientInput) (*cognitoidentityprovider.DescribeUserPoolClientOutput, error) {
 		tokenValidDays := int64(1)
+		refreshTokenUnits := cognitoidentityprovider.TimeUnitsTypeDays
+
 		userPoolClient := &cognitoidentityprovider.DescribeUserPoolClientOutput{
 			UserPoolClient: &cognitoidentityprovider.UserPoolClientType{
 				RefreshTokenValidity: &tokenValidDays,
+				TokenValidityUnits: &cognitoidentityprovider.TokenValidityUnitsType{
+					RefreshToken: &refreshTokenUnits,
+				},
 			},
 		}
 		return userPoolClient, nil

--- a/api/tokens_test.go
+++ b/api/tokens_test.go
@@ -466,11 +466,11 @@ func TestSignOutAllUsersGoRoutine(t *testing.T) {
 		signOutAllUsersTests := []struct {
 			listUsersFunction              func(userInput *cognitoidentityprovider.ListUsersInput) (*cognitoidentityprovider.ListUsersOutput, error)
 			adminUserGlobalSignOutFunction func(signOutInput *cognitoidentityprovider.AdminUserGlobalSignOutInput) (*cognitoidentityprovider.AdminUserGlobalSignOutOutput, error)
-			globalUserSignOutMod		   models.GlobalSignOut
-			numberOfUsers				   int
-			expectedResults				   int
+			globalUserSignOutMod           models.GlobalSignOut
+			numberOfUsers                  int
+			expectedResults                int
 			httpResponse                   int
-		}{	
+		}{
 			{
 				// 200 response from Cognito - 202 from identity api
 				func(userInput *cognitoidentityprovider.ListUsersInput) (*cognitoidentityprovider.ListUsersOutput, error) {
@@ -581,9 +581,9 @@ func TestSignOutAllUsersGetAllUsersList(t *testing.T) {
 	api, _, m := apiSetup()
 
 	Convey("Testing users global signout - go routine", t, func() {
-		var(
+		var (
 			paginationToken, usersFilterString string = "abc-123-xyz-345-xxx", "status=\"Enabled\""
-			backoff = []time.Duration{
+			backoff                                   = []time.Duration{
 				1 * time.Second,
 				2 * time.Second,
 				3 * time.Second,
@@ -595,7 +595,7 @@ func TestSignOutAllUsersGetAllUsersList(t *testing.T) {
 			BackoffSchedule   []time.Duration
 			expectedUserNumb  int
 			httpResponse      []int
-		}{	
+		}{
 			{
 				func(userInput *cognitoidentityprovider.ListUsersInput) (*cognitoidentityprovider.ListUsersOutput, error) {
 					if userInput.PaginationToken != nil {
@@ -624,7 +624,7 @@ func TestSignOutAllUsersGetAllUsersList(t *testing.T) {
 				},
 				backoff,
 				0,
-				[]int {
+				[]int{
 					http.StatusInternalServerError,
 				},
 			},
@@ -656,7 +656,7 @@ func TestSignOutAllUsersGetAllUsersList(t *testing.T) {
 			usersList, awsErr := api.ListUsersWorker(ctx, &usersFilterString, tt.BackoffSchedule)
 
 			// we should receive the expected number of processed usernames on the ResultsChannel
-			if (tt.httpResponse[errCode] >= http.StatusBadRequest) {
+			if tt.httpResponse[errCode] >= http.StatusBadRequest {
 				So(usersList, ShouldBeNil)
 				So(awsErr.Status, ShouldEqual, tt.httpResponse[errCode])
 			} else {

--- a/api/users.go
+++ b/api/users.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/ONSdigital/dp-identity-api/models"
 	"github.com/ONSdigital/dp-identity-api/query"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -11,8 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"io"
-	"net/http"
 )
 
 const (
@@ -272,7 +273,8 @@ func (api *API) ChangePasswordHandler(ctx context.Context, w http.ResponseWriter
 				return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, awsErr)
 			}
 
-			refreshTokenTTL := int(*userPoolClient.UserPoolClient.RefreshTokenValidity)
+			clientTokenValidityUnits := *userPoolClient.UserPoolClient.TokenValidityUnits
+			refreshTokenTTL := calculateTokenTTLInSeconds(*clientTokenValidityUnits.RefreshToken, int(*userPoolClient.UserPoolClient.RefreshTokenValidity))
 
 			jsonResponse, responseErr = changePasswordParams.BuildAuthChallengeSuccessfulJsonResponse(ctx, result, refreshTokenTTL)
 			if responseErr == nil {

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -1009,9 +1009,14 @@ func TestChangePasswordHandler(t *testing.T) {
 
 	m.DescribeUserPoolClientFunc = func(input *cognitoidentityprovider.DescribeUserPoolClientInput) (*cognitoidentityprovider.DescribeUserPoolClientOutput, error) {
 		tokenValidDays := int64(1)
+		refreshTokenUnits := cognitoidentityprovider.TimeUnitsTypeDays
+
 		userPoolClient := &cognitoidentityprovider.DescribeUserPoolClientOutput{
 			UserPoolClient: &cognitoidentityprovider.UserPoolClientType{
 				RefreshTokenValidity: &tokenValidDays,
+				TokenValidityUnits: &cognitoidentityprovider.TokenValidityUnitsType{
+					RefreshToken: &refreshTokenUnits,
+				},
 			},
 		}
 		return userPoolClient, nil

--- a/cognito/mock/cognito_stub.go
+++ b/cognito/mock/cognito_stub.go
@@ -698,9 +698,13 @@ func (m *CognitoIdentityProviderClientStub) ListGroups(input *cognitoidentitypro
 func (m *CognitoIdentityProviderClientStub) DescribeUserPoolClient(input *cognitoidentityprovider.DescribeUserPoolClientInput) (
 	*cognitoidentityprovider.DescribeUserPoolClientOutput, error) {
 	tokenValidDays := int64(1)
+	refreshTokenUnits := cognitoidentityprovider.TimeUnitsTypeDays
 	userPoolClient := &cognitoidentityprovider.DescribeUserPoolClientOutput{
 		UserPoolClient: &cognitoidentityprovider.UserPoolClientType{
 			RefreshTokenValidity: &tokenValidDays,
+			TokenValidityUnits: &cognitoidentityprovider.TokenValidityUnitsType{
+				RefreshToken: &refreshTokenUnits,
+			},
 		},
 	}
 	return userPoolClient, nil

--- a/models/users.go
+++ b/models/users.go
@@ -358,7 +358,7 @@ func (p *UserSignIn) BuildSuccessfulJsonResponse(ctx context.Context, result *co
 	if result.AuthenticationResult != nil {
 		tokenDuration := time.Duration(*result.AuthenticationResult.ExpiresIn)
 		expirationTime := time.Now().UTC().Add(time.Second * tokenDuration).String()
-		refreshTokenDuration := time.Duration(SecondsInDay * refreshTokenTTL)
+		refreshTokenDuration := time.Duration(refreshTokenTTL)
 		refreshTokenExpirationTime := time.Now().UTC().Add(time.Second * refreshTokenDuration).String()
 
 		postBody := map[string]interface{}{"expirationTime": expirationTime, "refreshTokenExpirationTime": refreshTokenExpirationTime}
@@ -430,7 +430,7 @@ func (p ChangePassword) BuildAuthChallengeSuccessfulJsonResponse(ctx context.Con
 	if result.AuthenticationResult != nil {
 		tokenDuration := time.Duration(*result.AuthenticationResult.ExpiresIn)
 		expirationTime := time.Now().UTC().Add(time.Second * tokenDuration).String()
-		refreshTokenDuration := time.Duration(SecondsInDay * refreshTokenTTL)
+		refreshTokenDuration := time.Duration(refreshTokenTTL)
 		refreshTokenExpirationTime := time.Now().UTC().Add(time.Second * refreshTokenDuration).String()
 
 		postBody := map[string]interface{}{"expirationTime": expirationTime, "refreshTokenExpirationTime": refreshTokenExpirationTime}


### PR DESCRIPTION
### What

dp-identity-api was setting a refresh token expiry date of 12 days when in fact it is 12 hours. 

This is because the api anticipates cognito will send it a unit in days - I've accounted for this and now it sets for 12 hours. 

### How to review

Connect to sandbox cognito using the instructions in the readme. 
Hit http://localhost:25600/v1/tokens
Check the refreshTokenExpirationTime to ensure it's now correct.

### Who can review

Backend dev. 