### PR TITLE
Feature/add reset account

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -110,6 +110,8 @@ func Setup(ctx context.Context,
 		Methods(http.MethodGet)
 	r.HandleFunc("/v1/users/{id}", auth.Require(UsersUpdatePermission, contextAndErrors(api.UpdateUserHandler))).
 		Methods(http.MethodPut)
+	r.HandleFunc("/v1/users/{id}/password", auth.Require(UsersUpdatePermission, contextAndErrors(api.UserSetPasswordHandler))).
+		Methods(http.MethodPost)
 	r.HandleFunc("/v1/users/{id}/groups", auth.Require(UsersReadPermission, contextAndErrors(api.ListUserGroupsHandler))).
 		Methods(http.MethodGet)
 	// self used in paths rather than identifier as the identifier is a Cognito Session string in change password requests

--- a/api/api.go
+++ b/api/api.go
@@ -192,14 +192,14 @@ func writeSuccessResponse(ctx context.Context, w http.ResponseWriter, successRes
 }
 
 func handleBodyReadError(ctx context.Context, err error) *models.ErrorResponse {
-	return models.NewErrorResponse(http.StatusInternalServerError,
+	return models.NewErrorResponse(http.StatusBadRequest,
 		nil,
 		models.NewError(ctx, err, models.BodyReadError, models.BodyReadFailedDescription),
 	)
 }
 
 func handleBodyUnmarshalError(ctx context.Context, err error) *models.ErrorResponse {
-	return models.NewErrorResponse(http.StatusInternalServerError,
+	return models.NewErrorResponse(http.StatusBadRequest,
 		nil,
 		models.NewError(ctx, err, models.JSONUnmarshalError, models.ErrorUnmarshalFailedDescription),
 	)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -309,12 +309,12 @@ func TestWriteSuccessResponse(t *testing.T) {
 }
 
 func TestHandleBodyReadError(t *testing.T) {
-	Convey("returns an ErrorResponse with a BodyReadError and 500 status", t, func() {
+	Convey("returns an ErrorResponse with a BodyReadError and 400 status", t, func() {
 		ctx := context.Background()
 		err := errors.New("TestError")
 		errResponse := handleBodyReadError(ctx, err)
 
-		So(errResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		So(errResponse.Status, ShouldEqual, http.StatusBadRequest)
 		castErr := errResponse.Errors[0].(*models.Error)
 		So(castErr.Code, ShouldEqual, models.BodyReadError)
 		So(castErr.Description, ShouldEqual, models.BodyReadFailedDescription)
@@ -322,12 +322,12 @@ func TestHandleBodyReadError(t *testing.T) {
 }
 
 func TestHandleBodyUnmarshalError(t *testing.T) {
-	Convey("returns an ErrorResponse with a JSONUnmarshalError and 500 status", t, func() {
+	Convey("returns an ErrorResponse with a JSONUnmarshalError and 400 status", t, func() {
 		ctx := context.Background()
 		err := errors.New("TestError")
 		errResponse := handleBodyUnmarshalError(ctx, err)
 
-		So(errResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		So(errResponse.Status, ShouldEqual, http.StatusBadRequest)
 		castErr := errResponse.Errors[0].(*models.Error)
 		So(castErr.Code, ShouldEqual, models.JSONUnmarshalError)
 		So(castErr.Description, ShouldEqual, models.ErrorUnmarshalFailedDescription)

--- a/api/users.go
+++ b/api/users.go
@@ -53,7 +53,7 @@ func (api *API) CreateUserHandler(ctx context.Context, _ http.ResponseWriter, re
 	listUserInput := models.UsersList{}.BuildListUserRequest("email = \""+user.Email+"\"", "email", int32(1), nil, &api.UserPoolID)
 	listUserResp, err := api.CognitoClient.ListUsers(ctx, listUserInput)
 	if err != nil {
-		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint"))
+		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, models.NewCognitoError(ctx, err, "ListUsers request from create users endpoint"))
 	}
 	duplicateEmailErr := user.CheckForDuplicateEmail(ctx, listUserResp)
 	if duplicateEmailErr != nil {
@@ -130,7 +130,7 @@ func (api *API) GetUserHandler(ctx context.Context, _ http.ResponseWriter, req *
 	userInput := user.BuildAdminGetUserRequest(api.UserPoolID)
 	userResp, err := api.CognitoClient.AdminGetUser(ctx, userInput)
 	if err != nil {
-		responseErr := models.NewCognitoError(ctx, err, "Cognito ListUsers request from create users endpoint")
+		responseErr := models.NewCognitoError(ctx, err, "AdminGetUser request from get user endpoint")
 		if responseErr.Code == models.UserNotFoundError {
 			return nil, models.NewErrorResponse(http.StatusNotFound, nil, responseErr)
 		}

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -28,6 +28,7 @@ func (c *IdentityComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^a user with email "([^"]*)" and password "([^"]*)" exists in the database$`, c.aUserWithEmailAndPasswordExistsInTheDatabase)
 	ctx.Step(`^a user with non-verified email "([^"]*)" and password "([^"]*)"$`, c.aUserWithNonverifiedEmailAndPassword)
 	ctx.Step(`^a user with username "([^"]*)" and email "([^"]*)" exists in the database$`, c.aUserWithUsernameAndEmailExistsInTheDatabase)
+	ctx.Step(`^a user with username "([^"]*)" exists in the database and is unconfirmed$`, c.aUserWithUsernameExistsInTheDatabaseAndIsUnconfirmed)
 	ctx.Step(`^a user with username "([^"]*)" and email "([^"]*)" and forename "([^"]*)" exists in the database$`, c.aUserWithUsernameAndEmailAndForenameExistsInTheDatabase)
 	ctx.Step(`^an error is returned from Cognito$`, c.anErrorIsReturnedFromCognito)
 	ctx.Step(`^an internal server error is returned from Cognito$`, c.anInternalServerErrorIsReturnedFromCognito)
@@ -67,6 +68,11 @@ func (c *IdentityComponent) aUserWithAttributesExistsInTheDatabase(forename, las
 
 func (c *IdentityComponent) aUserWithUsernameAndEmailExistsInTheDatabase(username, email string) error {
 	c.CognitoClient.AddUserWithUsername(username, email, true)
+	return nil
+}
+
+func (c *IdentityComponent) aUserWithUsernameExistsInTheDatabaseAndIsUnconfirmed(username string) error {
+	c.CognitoClient.AddUserWithUsername(username, "", false)
 	return nil
 }
 

--- a/features/users/create.feature
+++ b/features/users/create.feature
@@ -133,17 +133,21 @@ Feature: Users - Create
       }
       """
 
-  Scenario: POST /v1/users and checking the response status 500
+  Scenario: POST /v1/users and checking the response status 400
     Given I am an admin user
     When I POST "/v1/users"
       """
 
       """
-    Then I should receive the following JSON response with status "500":
+    Then I should receive the following JSON response with status "400":
       """
       {
-        "code": "InternalServerError",
-        "description": "Internal Server Error"
+        "errors": [
+          {
+            "code": "JSONUnmarshalError",
+            "description": "failed to unmarshal the request body"
+          }
+        ]
       }
       """
 

--- a/features/users/set_password.feature
+++ b/features/users/set_password.feature
@@ -1,0 +1,31 @@
+@Users @UsersSetPassword
+Feature: Users - Set Password
+  Scenario: POST /v1/users/{id}/password to set the passsword for unconfirmed user
+    Given a user with username "abcd1234" exists in the database and is unconfirmed
+    And I am an admin user
+    When I POST "/v1/users/abcd1234/password"
+    """
+    """
+    Then the HTTP status code should be "202"
+
+  Scenario: POST /v1/users/{id}/password to set the passsword for confirmed user
+    Given a user with username "abcd1234" and email "email@ons.gov.uk" exists in the database
+    And I am an admin user
+    When I POST "/v1/users/abcd1234/password"
+    """
+    """
+    Then the HTTP status code should be "403"
+
+  Scenario: POST /v1/users/{id}/password to set the passsword for unknown user
+    Given I am an admin user
+    When I POST "/v1/users/abcd1234/password"
+    """
+    """
+    Then the HTTP status code should be "404"
+
+  Scenario: POST /v1/users/{id}/password to set the passsword for unconfirmed user when not admin
+    Given a user with username "abcd1234" exists in the database and is unconfirmed
+    When I POST "/v1/users/abcd1234/password"
+    """
+    """
+    Then the HTTP status code should be "401"

--- a/models/error_content.go
+++ b/models/error_content.go
@@ -14,6 +14,7 @@ const (
 	InvalidEmailError            = "InvalidEmail"
 	InvalidTokenError            = "InvalidToken"
 	InternalError                = "InternalServerError"
+	InvalidStatusError           = "InvalidStatusError"
 	NotFoundError                = "NotFound"
 	UserNotFoundError            = "UserNotFound"
 	GroupExistsError             = "GroupExists"
@@ -85,6 +86,7 @@ const (
 	JWKSErrorDecodingDescription           = "error decoding json web key"
 	JWKSExponentErrorDescription           = "unexpected exponent: unable to decode JWK"
 	JWKSEmptyWebKeySetDescription          = "empty json web key set"
+	InvalidStatusDescription               = "user was not in a valid state to perform action"
 )
 
 // CognitoErrorMapping mapping Cognito error codes to API error codes

--- a/models/users.go
+++ b/models/users.go
@@ -277,6 +277,28 @@ func (p UserParams) BuildAdminGetUserRequest(userPoolID string) *cognitoidentity
 	}
 }
 
+// ValidateSetPasswordRequest validates the user to see if a SetPasswordRequest
+// should be made
+func (p UserParams) ValidateSetPasswordRequest(ctx context.Context) []error {
+	var validationErrs []error
+
+	if p.Status != types.UserStatusTypeForceChangePassword {
+		validationErrs = append(validationErrs, NewValidationError(ctx, InvalidStatusError, InvalidStatusDescription))
+	}
+
+	return validationErrs
+}
+
+// BuildSetPasswordRequest generates a AdminSetUserPasswordInput for Cognito
+func (p UserParams) BuildSetPasswordRequest(userPoolID string) *cognitoidentityprovider.AdminSetUserPasswordInput {
+	return &cognitoidentityprovider.AdminSetUserPasswordInput{
+		Username:   &p.ID,
+		Password:   &p.Password,
+		UserPoolId: &userPoolID,
+		Permanent:  true,
+	}
+}
+
 // MapCognitoDetails maps the details from the Cognito ListUser User model to the UserParams model
 func (p UserParams) MapCognitoDetails(userDetails types.UserType) UserParams {
 	var forename, surname, email, statusNotes string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -305,6 +305,33 @@ paths:
             $ref: '#/definitions/ErrorList'
         500:
           $ref: '#/responses/InternalError'
+  /users/{id}/password:
+    post:
+      tags:
+        - Users
+      summary: "Sets a generated password for a user"
+      description: "Sets a generated password for a user"
+      security:
+        - Authorization: []
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: the users id
+      responses:
+        202:
+          description: "Password setting processed"
+        400:
+          $ref: '#/responses/BadRequestError'
+        401:
+          $ref: '#/responses/UnauthorizedError'
+        404:
+          description: "User not found"
+          schema:
+            $ref: '#/definitions/ErrorList'
+        500:
+          $ref: '#/responses/InternalError'
   /users/{id}/groups:
     get:
       tags:


### PR DESCRIPTION
### What

Added a user reset button

### How to review

To setup for testing:

- Run dp-identity-api 
    - need to set env vars to connect to Cognito, there's a guide in dp-compose: https://github.com/ONSdigital/dp-compose/blob/main/v2/stacks/auth/README.md
    - set BlockPlusAddressing to false

Try the new endpoint: POST /v1/users/{id}/password

Some scenarios can be seen in the test files but also here:

- POST for non-existent user should result in 404
- POST for user not in FORCE_CHANGE_PASSWORD state should result in 403
- POST for user in FORCE_CHANGE_PASSWORD state should result in 202 and the user being set to confirmed.

### Who can review

Not me. 