### PR TITLE
Feature/update docs

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -865,29 +865,29 @@ definitions:
       expirationTime:
         type: string
         description: "Expiration Time, UTC ISO 8601"
-        example: "YYYY-MM-DD hh-mm-ssZ"
+        example: "YYYY-MM-DD hh:mm:ssZ"
   SignInExpirationTime:
     type: object
     properties:
       expirationTime:
         type: string
         description: "Expiration Time, UTC ISO 8601"
-        example: "YYYY-MM-DD hh-mm-ssZ"
+        example: "YYYY-MM-DD hh:mm:ssZ"
       refreshTokenExpirationTime:
         type: string
         description: "Expiration Time, UTC ISO 8601"
-        example: "YYYY-MM-DD hh-mm-ssZ"
+        example: "YYYY-MM-DD hh:mm:ssZ"
   PasswordResetExpirationTime:
     type: object
     properties:
       expirationTime:
         type: string
         description: "Expiration Time, UTC ISO 8601"
-        example: "YYYY-MM-DD hh-mm-ssZ"
+        example: "YYYY-MM-DD hh:mm:ssZ"
       refreshTokenExpirationTime:
         type: string
         description: "Refresh Token Expiration Time, UTC ISO 8601"
-        example: "YYYY-MM-DD hh-mm-ssZ"
+        example: "YYYY-MM-DD hh:mm:ssZ"
   NewGroup:
     description: "The new group details for the response body"
     type: object
@@ -921,11 +921,11 @@ definitions:
         description: "The date the group was created"
         type: string
         format: date-time
-        example: "YYYY-MM-DD hh-mm-ssZ"
+        example: "YYYY-MM-DD hh:mm:ssZ"
       last_modified_date:
         type: string
         format: date-time
-        example: "YYYY-MM-DD hh-mm-ssZ"
+        example: "YYYY-MM-DD hh:mm:ssZ"
       role_arn:
         type: string
       user_pool_id:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -862,7 +862,7 @@ definitions:
   ExpirationTime:
     type: object
     properties:
-      message:
+      expirationTime:
         type: string
         description: "Expiration Time, UTC ISO 8601"
         example: "YYYY-MM-DD hh-mm-ssZ"


### PR DESCRIPTION
### What

Corrected the response schema for refresh session (PUT /tokens/self)
Also updated the examples to the correct format. 

### How to review

Check looks ok - optionally, to test it matches the spec:

- sign into florence sandbox
- go to /api/v1/tokens/self
- get your refresh_token from the request_headers
- add that to a PUT request to /api/v1/tokens/self along with the id_token
- check the response schema

OR see this line here: https://github.com/ONSdigital/dp-identity-api/blob/27532d5c6f8ed3a6548dc91ee51d925ef2798739/models/tokens_models.go#L126 for the response schema. 

### Who can review

Not me. 