### PR TITLE
chore(DIS-4350): add protective monitoring to dp-identity-api

### DIFF
--- a/api/groups.go
+++ b/api/groups.go
@@ -87,7 +87,7 @@ func (api *API) CreateGroupHandler(ctx context.Context, _ http.ResponseWriter, r
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully created group", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully created group", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return createGroup.NewSuccessResponse(jsonResponse, http.StatusCreated, nil), nil
 }
 
@@ -136,7 +136,7 @@ func (api *API) UpdateGroupHandler(ctx context.Context, _ http.ResponseWriter, r
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully updated group", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully updated group", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return updateGroup.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
 }
 
@@ -191,7 +191,7 @@ func (api *API) AddUserToGroupHandler(ctx context.Context, _ http.ResponseWriter
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully added user to group", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully added user to group", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
 }
 
@@ -323,7 +323,7 @@ func (api *API) RemoveUserFromGroupHandler(ctx context.Context, _ http.ResponseW
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully removed user from group", authEntityData, models.ActionDelete, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully removed user from group", authEntityData, models.ActionDelete, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
 }
 
@@ -415,7 +415,7 @@ func (api *API) GetGroupHandler(ctx context.Context, _ http.ResponseWriter, req 
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully retrieved group", authEntityData, models.ActionRead, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully retrieved group", authEntityData, models.ActionRead, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
 }
 
@@ -438,7 +438,7 @@ func (api *API) DeleteGroupHandler(ctx context.Context, _ http.ResponseWriter, r
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, cognitoErr)
 	}
 
-	logAuditEvent(ctx, "successfully deleted group", authEntityData, models.ActionDelete, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully deleted group", authEntityData, models.ActionDelete, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(nil, http.StatusNoContent, nil), nil
 }
 
@@ -498,7 +498,7 @@ func (api *API) SetGroupUsersHandler(ctx context.Context, _ http.ResponseWriter,
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully updated group users", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully updated group users", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
 }
 

--- a/api/log_utils.go
+++ b/api/log_utils.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	"github.com/ONSdigital/dp-identity-api/v2/models"
@@ -11,12 +12,8 @@ import (
 // logAuditEvent produces protective monitoring logging for the API endpoints given successful requests.
 // should we be logging a failed request we also log the reason for this.
 func logAuditEvent(ctx context.Context, message string, authEntityData *authorisation.AuthEntityData, action models.Action,
-	endpoint string, outcome models.Outcome, errReason string) {
+	endpoint string, outcome models.Outcome, errReason string, auditEventParams *models.AuditEventParams) {
 	identityType := log.USER
-	if authEntityData.IsServiceAuth {
-		identityType = log.SERVICE
-	}
-
 	data := log.Data{
 		"action":   action,
 		"endpoint": endpoint,
@@ -27,11 +24,30 @@ func logAuditEvent(ctx context.Context, message string, authEntityData *authoris
 		data["reason"] = errReason
 	}
 
-	log.Info(
-		ctx,
-		message,
-		log.Classification(log.ProtectiveMonitoring),
-		log.Auth(identityType, authEntityData.EntityData.UserID),
-		data,
-	)
+	if authEntityData != nil {
+		if authEntityData.IsServiceAuth {
+			identityType = log.SERVICE
+		}
+		log.Info(
+			ctx,
+			message,
+			log.Classification(log.ProtectiveMonitoring),
+			log.Auth(identityType, authEntityData.EntityData.UserID),
+			data,
+		)
+		return
+	}
+
+	if auditEventParams != nil {
+		for _, value := range *auditEventParams {
+			auditEventParamsString := fmt.Sprint(value)
+			log.Info(
+				ctx,
+				message,
+				log.Classification(log.ProtectiveMonitoring),
+				log.Auth(identityType, auditEventParamsString),
+				data,
+			)
+		}
+	}
 }

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -22,11 +22,6 @@ func (api *API) TokensHandler(ctx context.Context, _ http.ResponseWriter, req *h
 			_ = models.NewError(ctx, err, models.BodyCloseError, models.BodyClosedFailedDescription)
 		}
 	}()
-	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
-	if !ok {
-		log.Error(ctx, "tokensHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
-		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
-	}
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, handleBodyReadError(ctx, err)
@@ -100,7 +95,11 @@ func (api *API) TokensHandler(ctx context.Context, _ http.ResponseWriter, req *h
 	if result.ChallengeName == NewPasswordChallenge {
 		httpStatus = http.StatusAccepted
 	}
-	logAuditEvent(ctx, "successfully signed in", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "")
+
+	auditEventParams := models.AuditEventParams{
+		"email": userSignIn.Email,
+	}
+	logAuditEvent(ctx, "successfully signed in", nil, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "", &auditEventParams)
 	return models.NewSuccessResponse(jsonResponse, httpStatus, headers), nil
 }
 
@@ -128,12 +127,6 @@ func (api *API) SignOutHandler(ctx context.Context, _ http.ResponseWriter, req *
 
 // RefreshHandler refreshes a users access token and returns new access and ID tokens, expiration time and the refresh token
 func (api *API) RefreshHandler(ctx context.Context, _ http.ResponseWriter, req *http.Request) (*models.SuccessResponse, *models.ErrorResponse) {
-	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
-	if !ok {
-		log.Error(ctx, "refreshHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
-		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
-	}
-
 	var validationErrs []error
 	refreshToken := models.RefreshToken{TokenString: req.Header.Get(RefreshTokenHeaderName)}
 	validationErr := refreshToken.Validate(ctx)
@@ -172,7 +165,10 @@ func (api *API) RefreshHandler(ctx context.Context, _ http.ResponseWriter, req *
 		IDTokenHeaderName:     *result.AuthenticationResult.IdToken,
 	}
 
-	logAuditEvent(ctx, "successfully refreshed tokens", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
+	auditEventParams := models.AuditEventParams{
+		"email": idToken.Claims.Email,
+	}
+	logAuditEvent(ctx, "successfully refreshed tokens", nil, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "", &auditEventParams)
 	return models.NewSuccessResponse(jsonResponse, http.StatusCreated, headers), nil
 }
 
@@ -203,7 +199,7 @@ func (api *API) SignOutAllUsersHandler(ctx context.Context, _ http.ResponseWrite
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, resErr)
 	}
 
-	logAuditEvent(ctx, "successfully signed out all users", authEntityData, models.ActionDelete, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully signed out all users", authEntityData, models.ActionDelete, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(postBody, http.StatusAccepted, nil), nil
 }
 

--- a/api/tokens.go
+++ b/api/tokens.go
@@ -22,6 +22,11 @@ func (api *API) TokensHandler(ctx context.Context, _ http.ResponseWriter, req *h
 			_ = models.NewError(ctx, err, models.BodyCloseError, models.BodyClosedFailedDescription)
 		}
 	}()
+	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
+	if !ok {
+		log.Error(ctx, "tokensHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
+		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
+	}
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, handleBodyReadError(ctx, err)
@@ -95,7 +100,7 @@ func (api *API) TokensHandler(ctx context.Context, _ http.ResponseWriter, req *h
 	if result.ChallengeName == NewPasswordChallenge {
 		httpStatus = http.StatusAccepted
 	}
-
+	logAuditEvent(ctx, "successfully signed in", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "")
 	return models.NewSuccessResponse(jsonResponse, httpStatus, headers), nil
 }
 
@@ -123,6 +128,12 @@ func (api *API) SignOutHandler(ctx context.Context, _ http.ResponseWriter, req *
 
 // RefreshHandler refreshes a users access token and returns new access and ID tokens, expiration time and the refresh token
 func (api *API) RefreshHandler(ctx context.Context, _ http.ResponseWriter, req *http.Request) (*models.SuccessResponse, *models.ErrorResponse) {
+	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
+	if !ok {
+		log.Error(ctx, "refreshHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
+		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
+	}
+
 	var validationErrs []error
 	refreshToken := models.RefreshToken{TokenString: req.Header.Get(RefreshTokenHeaderName)}
 	validationErr := refreshToken.Validate(ctx)
@@ -161,6 +172,7 @@ func (api *API) RefreshHandler(ctx context.Context, _ http.ResponseWriter, req *
 		IDTokenHeaderName:     *result.AuthenticationResult.IdToken,
 	}
 
+	logAuditEvent(ctx, "successfully refreshed tokens", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
 	return models.NewSuccessResponse(jsonResponse, http.StatusCreated, headers), nil
 }
 

--- a/api/tokens_test.go
+++ b/api/tokens_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -381,6 +382,43 @@ func TestAPI_RefreshHandler(t *testing.T) {
 		So(errorResponse.Status, ShouldEqual, http.StatusForbidden)
 		So(len(errorResponse.Errors), ShouldEqual, 1)
 		So(errorResponse.Errors[0].Error(), ShouldEqual, awsErr.Error())
+	})
+}
+
+func TestTokensProtectedHandlersRequireAuthEntityData(t *testing.T) {
+	var ctx = context.Background()
+
+	api, w, _ := apiMockSetup()
+
+	Convey("TokensHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
+		postBody := map[string]interface{}{
+			emailField:    testEmail,
+			passwordField: passwordField,
+		}
+		body, _ := json.Marshal(postBody)
+
+		r := httptest.NewRequest(http.MethodPost, signInEndPoint, bytes.NewReader(body))
+		successResponse, errorResponse := api.TokensHandler(ctx, w, r)
+
+		So(successResponse, ShouldBeNil)
+		So(errorResponse, ShouldNotBeNil)
+		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		handlerErr := errorResponse.Errors[0].(*models.Error)
+		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
+		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
+	})
+
+	Convey("RefreshHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
+		r := httptest.NewRequest(http.MethodPut, tokenRefreshEndPoint, http.NoBody)
+
+		successResponse, errorResponse := api.RefreshHandler(ctx, w, r)
+
+		So(successResponse, ShouldBeNil)
+		So(errorResponse, ShouldNotBeNil)
+		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		handlerErr := errorResponse.Errors[0].(*models.Error)
+		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
+		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
 	})
 }
 

--- a/api/tokens_test.go
+++ b/api/tokens_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -382,43 +381,6 @@ func TestAPI_RefreshHandler(t *testing.T) {
 		So(errorResponse.Status, ShouldEqual, http.StatusForbidden)
 		So(len(errorResponse.Errors), ShouldEqual, 1)
 		So(errorResponse.Errors[0].Error(), ShouldEqual, awsErr.Error())
-	})
-}
-
-func TestTokensProtectedHandlersRequireAuthEntityData(t *testing.T) {
-	var ctx = context.Background()
-
-	api, w, _ := apiMockSetup()
-
-	Convey("TokensHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
-		postBody := map[string]interface{}{
-			emailField:    testEmail,
-			passwordField: passwordField,
-		}
-		body, _ := json.Marshal(postBody)
-
-		r := httptest.NewRequest(http.MethodPost, signInEndPoint, bytes.NewReader(body))
-		successResponse, errorResponse := api.TokensHandler(ctx, w, r)
-
-		So(successResponse, ShouldBeNil)
-		So(errorResponse, ShouldNotBeNil)
-		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
-		handlerErr := errorResponse.Errors[0].(*models.Error)
-		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
-		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
-	})
-
-	Convey("RefreshHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
-		r := httptest.NewRequest(http.MethodPut, tokenRefreshEndPoint, http.NoBody)
-
-		successResponse, errorResponse := api.RefreshHandler(ctx, w, r)
-
-		So(successResponse, ShouldBeNil)
-		So(errorResponse, ShouldNotBeNil)
-		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
-		handlerErr := errorResponse.Errors[0].(*models.Error)
-		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
-		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
 	})
 }
 

--- a/api/users.go
+++ b/api/users.go
@@ -295,6 +295,8 @@ func processUpdateCognitoError(ctx context.Context, err error, errContext string
 }
 
 // ChangePasswordHandler processes changes to the users password
+//
+//nolint:gocyclo // dispatches between password change types; refactor pending per the TODO at the staticcheck directive below
 func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter, req *http.Request) (*models.SuccessResponse, *models.ErrorResponse) {
 	defer func() {
 		if err := req.Body.Close(); err != nil {
@@ -304,6 +306,12 @@ func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter
 	var jsonResponse []byte
 	var responseErr error
 	var headers map[string]string
+
+	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
+	if !ok {
+		log.Error(ctx, "changePasswordHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
+		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
+	}
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -386,6 +394,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
+	logAuditEvent(ctx, "successfully changed password", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
 	return models.NewSuccessResponse(jsonResponse, http.StatusAccepted, headers), nil
 }
 
@@ -396,6 +405,12 @@ func (api *API) PasswordResetHandler(ctx context.Context, _ http.ResponseWriter,
 			_ = models.NewError(ctx, err, models.BodyCloseError, models.BodyClosedFailedDescription)
 		}
 	}()
+
+	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
+	if !ok {
+		log.Error(ctx, "passwordResetHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
+		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
+	}
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -435,6 +450,7 @@ func (api *API) PasswordResetHandler(ctx context.Context, _ http.ResponseWriter,
 	}
 
 	log.Info(ctx, "password reset completed", log.Data{logKeyUserEmail: passwordResetParams.Email})
+	logAuditEvent(ctx, "successfully requested password reset", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
 
 	return models.NewSuccessResponse(nil, http.StatusAccepted, nil), nil
 }

--- a/api/users.go
+++ b/api/users.go
@@ -89,7 +89,7 @@ func (api *API) CreateUserHandler(ctx context.Context, _ http.ResponseWriter, re
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully created user", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully created user", authEntityData, models.ActionCreate, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(jsonResponse, http.StatusCreated, nil), nil
 }
 
@@ -221,7 +221,7 @@ func (api *API) UpdateUserHandler(ctx context.Context, _ http.ResponseWriter, re
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully updated user", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully updated user", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(jsonResponse, http.StatusOK, nil), nil
 }
 
@@ -277,7 +277,7 @@ func (api *API) UserSetPasswordHandler(ctx context.Context, _ http.ResponseWrite
 
 	log.Info(ctx, "user set password completed", log.Data{"userID": userID})
 
-	logAuditEvent(ctx, "successfully set user password", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully set user password", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "", nil)
 	return models.NewSuccessResponse(nil, http.StatusAccepted, nil), nil
 }
 
@@ -307,12 +307,6 @@ func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter
 	var responseErr error
 	var headers map[string]string
 
-	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
-	if !ok {
-		log.Error(ctx, "changePasswordHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
-		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
-	}
-
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, handleBodyReadError(ctx, err)
@@ -324,6 +318,9 @@ func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter
 		return nil, handleBodyUnmarshalError(ctx, err)
 	}
 
+	auditEventParams := models.AuditEventParams{
+		"email": changePasswordParams.Email,
+	}
 	//nolint:staticcheck // making this into a switch statement would not improve it
 	// that much. TODO: It needs a greater level of refactoring
 	if changePasswordParams.ChangeType == models.NewPasswordRequiredType {
@@ -341,6 +338,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter
 			if parsedErr.Code == models.InternalError {
 				return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, parsedErr)
 			} else if parsedErr.Code == models.InvalidPasswordError || parsedErr.Code == models.InvalidCodeError {
+				logAuditEvent(ctx, "failed to change password", nil, models.ActionUpdate, req.URL.Path, models.OutcomeFailure, parsedErr.Error(), &auditEventParams)
 				return nil, models.NewErrorResponse(http.StatusBadRequest, nil, parsedErr)
 			}
 		} else {
@@ -382,6 +380,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter
 			if parsedErr.Code == models.InternalError {
 				return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, parsedErr)
 			} else if parsedErr.Code == models.InvalidPasswordError || parsedErr.Code == models.InvalidCodeError || parsedErr.Code == models.ExpiredCodeError {
+				logAuditEvent(ctx, "failed to change password", nil, models.ActionUpdate, req.URL.Path, models.OutcomeFailure, parsedErr.Error(), &auditEventParams)
 				return nil, models.NewErrorResponse(http.StatusBadRequest, nil, parsedErr)
 			}
 		}
@@ -394,7 +393,7 @@ func (api *API) ChangePasswordHandler(ctx context.Context, _ http.ResponseWriter
 		return nil, models.NewErrorResponse(http.StatusInternalServerError, nil, responseErr)
 	}
 
-	logAuditEvent(ctx, "successfully changed password", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully changed password", nil, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "", &auditEventParams)
 	return models.NewSuccessResponse(jsonResponse, http.StatusAccepted, headers), nil
 }
 
@@ -405,13 +404,6 @@ func (api *API) PasswordResetHandler(ctx context.Context, _ http.ResponseWriter,
 			_ = models.NewError(ctx, err, models.BodyCloseError, models.BodyClosedFailedDescription)
 		}
 	}()
-
-	authEntityData, ok := authorisation.AuthEntityDataFromContext(req.Context())
-	if !ok {
-		log.Error(ctx, "passwordResetHandler endpoint: failed to parse auth entity data", errors.New(models.EntityDataErrorDescription))
-		return nil, handleAuthEntityDataError(ctx, errors.New(models.EntityDataErrorDescription), nil)
-	}
-
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Error(ctx, "failed to read request body", err)
@@ -449,8 +441,11 @@ func (api *API) PasswordResetHandler(ctx context.Context, _ http.ResponseWriter,
 		}
 	}
 
+	auditEventParams := models.AuditEventParams{
+		"email": passwordResetParams.Email,
+	}
 	log.Info(ctx, "password reset completed", log.Data{logKeyUserEmail: passwordResetParams.Email})
-	logAuditEvent(ctx, "successfully requested password reset", authEntityData, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "")
+	logAuditEvent(ctx, "successfully requested password reset", nil, models.ActionUpdate, req.URL.Path, models.OutcomeSuccess, "", &auditEventParams)
 
 	return models.NewSuccessResponse(nil, http.StatusAccepted, nil), nil
 }

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -293,36 +293,6 @@ func TestProtectedHandlersRequireAuthEntityData(t *testing.T) {
 		So(createHandlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
 		So(createHandlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
 	})
-
-	Convey("ChangePasswordHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
-		postBody := map[string]interface{}{"type": models.NewPasswordRequiredType, emailField: "foo_bar123@ext.ons.gov.uk", passwordField: "Password2", "session": "auth-challenge-session"}
-		body, _ := json.Marshal(postBody)
-
-		r := httptest.NewRequest(http.MethodPut, changePasswordEndPoint, bytes.NewReader(body))
-		successResponse, errorResponse := api.ChangePasswordHandler(ctx, w, r)
-
-		So(successResponse, ShouldBeNil)
-		So(errorResponse, ShouldNotBeNil)
-		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
-		handlerErr := errorResponse.Errors[0].(*models.Error)
-		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
-		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
-	})
-
-	Convey("PasswordResetHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
-		postBody := map[string]interface{}{emailField: "foo_bar123@ext.ons.gov.uk"}
-		body, _ := json.Marshal(postBody)
-
-		r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(body))
-		successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
-
-		So(successResponse, ShouldBeNil)
-		So(errorResponse, ShouldNotBeNil)
-		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
-		handlerErr := errorResponse.Errors[0].(*models.Error)
-		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
-		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
-	})
 }
 
 func TestListUserHandler(t *testing.T) {

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -293,6 +293,36 @@ func TestProtectedHandlersRequireAuthEntityData(t *testing.T) {
 		So(createHandlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
 		So(createHandlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
 	})
+
+	Convey("ChangePasswordHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
+		postBody := map[string]interface{}{"type": models.NewPasswordRequiredType, emailField: "foo_bar123@ext.ons.gov.uk", passwordField: "Password2", "session": "auth-challenge-session"}
+		body, _ := json.Marshal(postBody)
+
+		r := httptest.NewRequest(http.MethodPut, changePasswordEndPoint, bytes.NewReader(body))
+		successResponse, errorResponse := api.ChangePasswordHandler(ctx, w, r)
+
+		So(successResponse, ShouldBeNil)
+		So(errorResponse, ShouldNotBeNil)
+		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		handlerErr := errorResponse.Errors[0].(*models.Error)
+		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
+		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
+	})
+
+	Convey("PasswordResetHandler returns GetAuthEntityDataError when auth entity data is missing", t, func() {
+		postBody := map[string]interface{}{emailField: "foo_bar123@ext.ons.gov.uk"}
+		body, _ := json.Marshal(postBody)
+
+		r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(body))
+		successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
+
+		So(successResponse, ShouldBeNil)
+		So(errorResponse, ShouldNotBeNil)
+		So(errorResponse.Status, ShouldEqual, http.StatusInternalServerError)
+		handlerErr := errorResponse.Errors[0].(*models.Error)
+		So(handlerErr.Code, ShouldEqual, models.GetAuthEntityDataError)
+		So(handlerErr.Description, ShouldEqual, models.GetAuthEntityDataErrorDescription)
+	})
 }
 
 func TestListUserHandler(t *testing.T) {
@@ -1268,6 +1298,7 @@ func TestChangePasswordHandler(t *testing.T) {
 			postBody := map[string]interface{}{"type": models.NewPasswordRequiredType, emailField: email, passwordField: password, "session": session}
 			body, _ := json.Marshal(postBody)
 			r := httptest.NewRequest(http.MethodPut, changePasswordEndPoint, bytes.NewReader(body))
+			r = addAuthEntityDataToRequest(r)
 			successResponse, errorResponse := api.ChangePasswordHandler(ctx, w, r)
 			tt.assertions(successResponse, errorResponse)
 		}
@@ -1372,6 +1403,7 @@ func TestConfirmForgotPasswordChangePasswordHandler(t *testing.T) {
 			postBody := map[string]interface{}{"type": models.ForgottenPasswordType, emailField: email, passwordField: password, "verification_token": verificationToken}
 			body, _ := json.Marshal(postBody)
 			r := httptest.NewRequest(http.MethodPut, changePasswordEndPoint, bytes.NewReader(body))
+			r = addAuthEntityDataToRequest(r)
 
 			successResponse, errorResponse := api.ChangePasswordHandler(ctx, w, r)
 
@@ -1421,6 +1453,7 @@ func TestConfirmForgotPasswordChangePasswordHandler(t *testing.T) {
 		for _, tt := range validationTests {
 			body, _ := json.Marshal(tt.requestBody)
 			r := httptest.NewRequest(http.MethodPut, changePasswordEndPoint, bytes.NewReader(body))
+			r = addAuthEntityDataToRequest(r)
 
 			successResponse, errorResponse := api.ChangePasswordHandler(ctx, w, r)
 
@@ -1503,6 +1536,7 @@ func TestPasswordResetHandler(t *testing.T) {
 			postBody := map[string]interface{}{emailField: email}
 			body, _ := json.Marshal(postBody)
 			r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(body))
+			r = addAuthEntityDataToRequest(r)
 
 			successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
 
@@ -1519,6 +1553,7 @@ func TestPasswordResetHandler(t *testing.T) {
 
 	Convey("ForgotPassword returns 500: error unmarshalling request body", t, func() {
 		r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(nil))
+		r = addAuthEntityDataToRequest(r)
 
 		successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
 
@@ -1545,6 +1580,7 @@ func TestPasswordResetHandler(t *testing.T) {
 		for _, tt := range validationTests {
 			body, _ := json.Marshal(tt.requestBody)
 			r := httptest.NewRequest(http.MethodPost, requestResetEndPoint, bytes.NewReader(body))
+			r = addAuthEntityDataToRequest(r)
 
 			successResponse, errorResponse := api.PasswordResetHandler(ctx, w, r)
 

--- a/models/audit_event.go
+++ b/models/audit_event.go
@@ -6,6 +6,8 @@ type Action string
 // Outcome represents the outcome of the action given the request to the API
 type Outcome string
 
+type AuditEventParams map[string]interface{}
+
 const (
 	ActionCreate Action = "CREATE"
 	ActionRead   Action = "READ"


### PR DESCRIPTION
### What

Added missing coverage for protective monitoring to the following routes through their respective handlers:

POST /tokens 
PUT /tokens/self
PUT /users/self/password
POST /password-reset

Adapted logging util function to be able to handle non AuthEntityData types
### How to review

Protective monitoring on completion of the routes

### Who can review

!me
